### PR TITLE
Dependent destroy added to participant status

### DIFF
--- a/app/models/participant.rb
+++ b/app/models/participant.rb
@@ -36,7 +36,9 @@ class Participant < ActiveRecord::Base
   has_many :phq_assessments, dependent: :destroy
   has_many :wai_assessments, dependent: :destroy
   has_many :participant_tokens, dependent: :destroy
-  has_one :participant_status, class_name: "BitPlayer::ParticipantStatus"
+  has_one :participant_status,
+          class_name: "BitPlayer::ParticipantStatus",
+          dependent: :destroy
   has_one :coach_assignment, dependent: :destroy
   has_one :coach, class_name: "User", through: :coach_assignment
   has_many :participant_login_events, dependent: :destroy


### PR DESCRIPTION
Bug fix: Participants need to be able to be deleted and they can't if there isn't a dependent destroy on participant_status.