### PR TITLE
Preselect Content Module

### DIFF
--- a/app/controllers/think_feel_do_engine/bit_maker/content_providers_controller.rb
+++ b/app/controllers/think_feel_do_engine/bit_maker/content_providers_controller.rb
@@ -23,7 +23,11 @@ module ThinkFeelDoEngine
 
       def new
         authorize! :new, BitCore::ContentProvider
-        @content_provider = ContentProviderDecorator.new
+        @content_provider = ContentProviderDecorator
+                            .new(
+                              bit_core_content_module_id:
+                              params[:bit_core_content_module_id]
+                            )
       end
 
       def edit

--- a/app/views/think_feel_do_engine/bit_maker/content_modules/show.html.erb
+++ b/app/views/think_feel_do_engine/bit_maker/content_modules/show.html.erb
@@ -3,7 +3,7 @@
 <div class="btn-toolbar" role="toolbar">
   <%= link_to 'Modules', arm_bit_maker_content_modules_path(@arm), class: "btn btn-default" %>
   <%= link_to 'Edit', edit_arm_bit_maker_content_module_path(@arm, @content_module), class: "btn btn-default" %>
-  <%= link_to "New Provider", new_arm_bit_maker_content_provider_path(@arm), class: "btn btn-default" %>
+  <%= link_to "New Provider", new_arm_bit_maker_content_provider_path(@arm, bit_core_content_module_id: @content_module.id), class: "btn btn-default" %>
   <%= link_to 'Destroy', arm_bit_maker_content_module_path(@arm, @content_module), method: :delete, data: { confirm: 'Are you sure?' }, class: "btn btn-danger" %>
 </div>
 

--- a/spec/features/content_author/bit_maker/content_module_spec.rb
+++ b/spec/features/content_author/bit_maker/content_module_spec.rb
@@ -45,6 +45,13 @@ feature "Content Modules", type: :feature do
       expect(page).to_not have_content "#1 Awareness"
     end
 
+    it "should prepopulate the title of the Content Module when adding a provider to an exisiting module" do
+      visit "/arms/#{arms(:arm1).id}/bit_maker/content_modules/#{do_awareness.id}"
+      click_on "New Provider"
+
+      expect(page).to have_select("Bit core content module", selected: "DO: #{do_awareness.title}")
+    end
+
     it "should scope modules by arm" do
       visit "/arms/#{arms(:arm2).id}/bit_maker/content_modules"
 

--- a/spec/features/content_author/bit_maker/content_provider_spec.rb
+++ b/spec/features/content_author/bit_maker/content_provider_spec.rb
@@ -26,10 +26,6 @@ feature "Content Provider", type: :feature do
       visit "/arms/#{arms(:arm1).id}/bit_maker/content_modules"
 
       expect(page).to have_link "New Provider", href: "/arms/#{arms(:arm1).id}/bit_maker/content_providers/new"
-
-      visit "/arms/#{arms(:arm1).id}/bit_maker/content_modules/#{bit_core_content_modules(:do_awareness).id}"
-
-      expect(page).to have_link "New Provider", href: "/arms/#{arms(:arm1).id}/bit_maker/content_providers/new"
     end
 
     it "should scope modules by arm when on new" do


### PR DESCRIPTION
* Content provider form now
  preselects the content module
  if you navigate to the "new"
  page from the content module
  "show" page.
* [Finishes: #88450202]