### PR TITLE
Remove Effect From Thoughts Table

### DIFF
--- a/app/views/think_feel_do_engine/thoughts/_mutable_thought.html.erb
+++ b/app/views/think_feel_do_engine/thoughts/_mutable_thought.html.erb
@@ -4,10 +4,6 @@
     <%= text_field_tag "thoughts[#{ mutable_thought.id }][content]", mutable_thought.content, class: "not-displayed" %>
   </td>
   <td>
-    <span class="immutable-thought-content"><%= mutable_thought.effect %></span>
-    <%= select_tag "thoughts[#{ mutable_thought.id }][effect]", options_for_select(%w(helpful harmful neither), mutable_thought.effect), class: "not-displayed" %>
-  </td>
-  <td>
     <span class="immutable-thought-content"><%= (!mutable_thought.pattern_title.blank? ? mutable_thought.pattern_title : "<span class=\"label label-warning\">Not Answered</span>".html_safe) %></span>
     <%= select_tag "thoughts[#{ mutable_thought.id }][pattern_id]", options_from_collection_for_select(ThoughtPattern.all, "id", "title", mutable_thought.pattern_id), include_blank: true, class: "not-displayed" %>
   </td>

--- a/app/views/think_feel_do_engine/thoughts/thoughts_table.html.erb
+++ b/app/views/think_feel_do_engine/thoughts/thoughts_table.html.erb
@@ -12,7 +12,6 @@
 <table class="table table-hover data-table responsive" id="thoughts">
   <thead>
     <th>Thought</th>
-    <th>Effect</th>
     <th>Pattern</th>
     <th>Challenging Thought</th>
     <th>As If Action</th>

--- a/spec/features/participant/thought_tracker_spec.rb
+++ b/spec/features/participant/thought_tracker_spec.rb
@@ -224,6 +224,16 @@ feature "thought tracker", type: :feature do
     expect(page).to have_selector(:link_or_button, "Next")
   end
 
+  it "should not display a way to updated harmful thought's effect" do
+    visit "/navigator/modules/#{bit_core_content_modules(:think_module_thoughts_table).id}"
+    click_on "Edit Thoughts"
+
+    expect(page).to_not have_content "Effect"
+    expect(page).to_not have_content "harmful"
+    expect(page).to_not have_content "helpful"
+    expect(page).to_not have_content "neither"
+  end
+
   it "shows a vizualization of thought distortions and their associated harmful thoughts", :js do
     page.find(".list-group-item-unread", text: "Add a New Thought").click
     fill_in "thought_content", with: "something something"


### PR DESCRIPTION
* Remove "Effect" column.
* Harmful thoughts table only displays  
  harmful thoughts - the participant  
  can no longer edit the "effect" to  
  'helfpul' or 'neither' from this page.
* [Finishes: #88524260]