### PR TITLE
Msw activity is complete

### DIFF
--- a/app/helpers/think_feel_do_engine/coach/activity_color_code_helper.rb
+++ b/app/helpers/think_feel_do_engine/coach/activity_color_code_helper.rb
@@ -9,7 +9,7 @@ module ThinkFeelDoEngine
       # danger - red
 
       def get_color_class(activity)
-        if activity.completed? && activity.rated?
+        if activity.reviewed_and_complete? && activity.rated?
           rating_color(
             activity.actual_pleasure_intensity,
             activity.actual_accomplishment_intensity

--- a/app/models/activity.rb
+++ b/app/models/activity.rb
@@ -9,7 +9,6 @@ class Activity < ActiveRecord::Base
   belongs_to :participant
 
   validates :activity_type, :participant, presence: true
-  validates :is_complete, inclusion: { in: [true, false] }
 
   delegate :title, to: :activity_type, prefix: false, allow_nil: true
 

--- a/app/models/activity.rb
+++ b/app/models/activity.rb
@@ -81,9 +81,15 @@ class Activity < ActiveRecord::Base
     )
   }
 
-  scope :incomplete, lambda {
-    where(is_complete: false)
-      .where(noncompliance_reason: nil)
+  scope :planned, lambda {
+    where(
+      is_reviewed: false,
+      actual_accomplishment_intensity: nil,
+      actual_pleasure_intensity: nil)
+      .where
+      .not(
+        predicted_accomplishment_intensity: nil,
+        predicted_pleasure_intensity: nil)
   }
 
   scope :random, lambda {

--- a/app/models/content_providers/past_activity_form.rb
+++ b/app/models/content_providers/past_activity_form.rb
@@ -19,8 +19,7 @@ module ContentProviders
         :end_time,
         :activity_type_title,
         :actual_pleasure_intensity,
-        :actual_accomplishment_intensity,
-        :is_complete
+        :actual_accomplishment_intensity
       ]
     end
 

--- a/app/models/content_providers/past_activity_review_form.rb
+++ b/app/models/content_providers/past_activity_review_form.rb
@@ -25,7 +25,7 @@ module ContentProviders
     def data_attributes
       [
         :id, :actual_pleasure_intensity, :actual_accomplishment_intensity,
-        :is_complete, :noncompliance_reason
+        :noncompliance_reason
       ]
     end
 

--- a/app/models/content_providers/past_activity_review_form.rb
+++ b/app/models/content_providers/past_activity_review_form.rb
@@ -7,7 +7,7 @@ module ContentProviders
         .participant
         .activities
         .in_the_past
-        .incomplete
+        .planned
 
       options.view_context.render(
         template: "think_feel_do_engine/activities/past_activity_review",

--- a/app/models/content_providers/past_due_activities_viz.rb
+++ b/app/models/content_providers/past_due_activities_viz.rb
@@ -24,7 +24,7 @@ module ContentProviders
         .participant
         .activities
         .in_the_past
-        .incomplete
+        .planned
         .order(start_time: :desc)
     end
 
@@ -33,7 +33,7 @@ module ContentProviders
         .participant
         .activities
         .in_the_future
-        .incomplete
+        .planned
         .order(start_time: :asc)
     end
   end

--- a/app/models/content_providers/previous_planned_activities_provider.rb
+++ b/app/models/content_providers/previous_planned_activities_provider.rb
@@ -24,7 +24,7 @@ module ContentProviders
     def data_attributes
       [
         :id, :actual_pleasure_intensity, :actual_accomplishment_intensity,
-        :is_complete, :noncompliance_reason
+        :noncompliance_reason
       ]
     end
 

--- a/app/models/content_providers/previous_planned_activities_provider.rb
+++ b/app/models/content_providers/previous_planned_activities_provider.rb
@@ -6,7 +6,7 @@ module ContentProviders
         options
         .participant
         .activities
-        .incomplete
+        .planned
 
       options.view_context.render(
         template: "think_feel_do_engine/activities/previously_planned_fullpage",

--- a/app/models/content_providers/your_activities_provider.rb
+++ b/app/models/content_providers/your_activities_provider.rb
@@ -62,7 +62,7 @@ module ContentProviders
         .participant
         .activities
         .last_seven_days
-        .completed
+        .reviewed_and_completed
         .order(start_time: :asc)
     end
 

--- a/app/views/think_feel_do_engine/activities/_activity_coach_view.html.erb
+++ b/app/views/think_feel_do_engine/activities/_activity_coach_view.html.erb
@@ -1,6 +1,6 @@
 <tr>
   <td><%= activity.title %></td>
-  <td><%= activity.is_complete? ? "<span class=\"label label-success\">Completed</span>".html_safe : "<span class=\"label label-warning\">Inactive</span>".html_safe %></td>
+  <td><%= activity.reviewed_and_complete? ? "<span class=\"label label-success\">Completed</span>".html_safe : "<span class=\"label label-warning\">Inactive</span>".html_safe %></td>
   <td><%= activity.start_time? ? "Scheduled for #{ activity.start_time.to_formatted_s(:short) }" : "Unscheduled" %></td>
   <td><%= activity.created_at.to_formatted_s(:short) %></td>
 </tr>

--- a/app/views/think_feel_do_engine/activities/_activity_coach_view_past.html.erb
+++ b/app/views/think_feel_do_engine/activities/_activity_coach_view_past.html.erb
@@ -6,13 +6,10 @@
     <%= activity.created_at ? activity.created_at.to_i : 0 %>
   </td>
   <td><%= activity.title %></td>
-  <td><%= activity.monitored? ? "Monitored" : "Planned" %></td>
   <td>
-    <% if activity.is_complete? %>
-      <span class="label label-success">Completed</span>
-    <% elsif activity.noncompliance_reason.present? %>
-      <span class="label label-warning">Not Completed</span>
-      <button type="button" class="btn btn-link" data-toggle="popoper" title="Why was this not completed?" data-content="<%= activity.noncompliance_reason %>" onmouseover="$(this).popover();">more info</button>
+    <%= activity.status_label %>
+    <% if activity.noncompliance_reason.present? %>
+      <button type="button" class="btn btn-link" data-toggle="popoper" title="Why was this not completed?" data-content="<%= activity.noncompliance_reason %>" onmouseover="$(this).popover();">Noncompliance</button>
     <% end %>
   </td>
   <td><%= activity.predicted_pleasure_intensity ? activity.predicted_pleasure_intensity : "<span class=\"label label-warning\">Not Rated</span>".html_safe %></td>

--- a/app/views/think_feel_do_engine/activities/_daily_summary.html.erb
+++ b/app/views/think_feel_do_engine/activities/_daily_summary.html.erb
@@ -26,13 +26,13 @@
         </p>
         <p>
           Completion Score: <%= activities.scheduled.completion_score %>%
-          (You completed <%= activities.scheduled.completed.count %> out of <%= pluralize(activities.scheduled.count, 'activity') %> that you scheduled.)
+          (You completed <%= activities.scheduled.reviewed_and_completed.count %> out of <%= pluralize(activities.scheduled.count, 'activity') %> that you scheduled.)
         <p>
         <p>
-          <strong>Average Accomplishment Discrepancy:</strong> <%= average_intensity_difference(activities.completed, :accomplishment) %>
+          <strong>Average Accomplishment Discrepancy:</strong> <%= average_intensity_difference(activities.reviewed_and_completed, :accomplishment) %>
         </p>
         </p>
-          <strong>Average Pleasure Discrepancy:</strong> <%= average_intensity_difference(activities.completed, :pleasure) %>
+          <strong>Average Pleasure Discrepancy:</strong> <%= average_intensity_difference(activities.reviewed_and_completed, :pleasure) %>
         </p>
       </div>
     </div>

--- a/app/views/think_feel_do_engine/activities/past_activity_form.html.erb
+++ b/app/views/think_feel_do_engine/activities/past_activity_form.html.erb
@@ -18,7 +18,6 @@
       ) do |f| %>
       <%= f.hidden_field :start_time, value: start_time %>
       <%= f.hidden_field :end_time, value: end_time %>
-      <%= f.hidden_field :is_complete, value: true %>
 
       <div class="row">
         <div class="form-group col-lg-12">

--- a/app/views/think_feel_do_engine/activities/past_activity_review.html.erb
+++ b/app/views/think_feel_do_engine/activities/past_activity_review.html.erb
@@ -22,11 +22,11 @@
       <strong>Did you?</strong>
 
       <div class="btn-group" data-toggle="buttons">
-        <label class="btn btn-success">
-          <%= f.radio_button :is_complete, true, { id: "activity_is_complete_yes_#{ activity.id }", :"data-activity-id" => activity.id, class: "radio_yes" } %> Yes
+        <label class="btn btn-success active">
+          <%= content_tag(:input, "Yes", class: "radio_yes", :'data-activity-id' => "#{activity.id}", id: "activity_is_complete_yes_#{activity.id}", name: "activity[is_complete]", type: "radio", value: "true") %>
         </label>
         <label class="btn btn-danger">
-          <%= f.radio_button :is_complete, false, { id: "activity_is_complete_no_#{ activity.id }", :"data-activity-id" => activity.id, class: "radio_no" } %> No
+          <%= content_tag(:input, "No", class: "radio_no", :'data-activity-id' => "#{activity.id}", id: "activity_is_complete_no_#{activity.id}", name: "activity[is_complete]", type: "radio", value: "false") %>
         </label>
       </div>
 

--- a/app/views/think_feel_do_engine/coach/patient_dashboards/show.html.erb
+++ b/app/views/think_feel_do_engine/coach/patient_dashboards/show.html.erb
@@ -328,7 +328,6 @@
                 <th class="not-displayed"></th>
                 <th class="not-displayed"></th>
                 <th>Activity</th>
-                <th>Planned/Monitored</th>
                 <th>Status</th>
                 <th>Predicted Pleasure Rating</th>
                 <th>Predicted Accomplishment Rating</th>
@@ -623,7 +622,7 @@
                   bVisible: false
               },
               {
-                  aTargets: [9],
+                  aTargets: [8],
                   iDataSort: [0]
               },
               {
@@ -631,7 +630,7 @@
                   bVisible: false
               },
               {
-                  aTargets: [10],
+                  aTargets: [9],
                   iDataSort: [1]
               }
           ]

--- a/db/migrate/20150227221640_remove_is_complete_from_activities.rb
+++ b/db/migrate/20150227221640_remove_is_complete_from_activities.rb
@@ -1,0 +1,5 @@
+class RemoveIsCompleteFromActivities < ActiveRecord::Migration
+  def change
+    remove_column :activities, :is_complete, :boolean, default: false, null: false
+  end
+end

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150226210641) do
+ActiveRecord::Schema.define(version: 20150227221640) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -25,7 +25,6 @@ ActiveRecord::Schema.define(version: 20150226210641) do
     t.integer  "actual_pleasure_intensity"
     t.integer  "predicted_accomplishment_intensity"
     t.integer  "predicted_pleasure_intensity"
-    t.boolean  "is_complete",                        default: false, null: false
     t.text     "noncompliance_reason"
     t.datetime "created_at"
     t.datetime "updated_at"

--- a/spec/features/coach/patient_dashboard_spec.rb
+++ b/spec/features/coach/patient_dashboard_spec.rb
@@ -288,9 +288,8 @@ feature "patient dashboard", type: :feature do
               "Loving",
               "Planned",
               "Not Rated",
-              "6",
               "Not Rated",
-              "Scheduled for #{ (Time.current - 2.hour).to_formatted_s(:short) }",
+              "Scheduled for #{ (Time.current - 4.hour).to_formatted_s(:short) }",
               short_timestamp
             ]
           )
@@ -321,11 +320,10 @@ feature "patient dashboard", type: :feature do
             cells: [
               "run",
               "Monitored",
-              "Completed",
               "Not Rated",
               "Not Rated",
-              "Not Rated",
-              "Not Rated",
+              "0",
+              "0",
               "Scheduled for #{ (time_now - 2.hour).to_formatted_s(:short) }",
               short_timestamp
             ]

--- a/spec/features/participant/activities/content_providers/past_activity_review_form_spec.rb
+++ b/spec/features/participant/activities/content_providers/past_activity_review_form_spec.rb
@@ -5,29 +5,30 @@ feature "Activities", type: :feature do
 
   describe "When in Do #3 Doing" do
     describe "ContentProvider::PastActivityReviewForm" do
-      scenario "Participant reviews an activity they completed" do
+      let(:activity) { activities(:planned_activity0) }
+
+      before :each do
         sign_in_participant participants(:participant1)
         visit "/navigator/modules/#{ bit_core_content_modules(:do_doing).id }" \
                   "/providers/" \
               "#{ bit_core_content_providers(:do_doing_past_activity_review).id }/1"
+      end
 
-        expect(page).to have_text "You said you were going to Loving"
-        choose("activity_is_complete_yes_227206994")
+      scenario "Participant reviews an activity they completed" do
+        choose("activity_is_complete_yes_#{activity.id}")
         select 9, from: "activity[actual_accomplishment_intensity]"
         select 4, from: "activity[actual_pleasure_intensity]"
         click_on "Next"
+
+        expect("Activity Saved")
       end
 
       scenario "Participant reviews an activity they did not complete" do
-        sign_in_participant participants(:participant1)
-        visit "/navigator/modules/#{ bit_core_content_modules(:do_doing).id }" \
-                  "/providers/" \
-              "#{ bit_core_content_providers(:do_doing_past_activity_review).id }/1"
-
-        expect(page).to have_text "You said you were going to Loving"
-        choose("activity_is_complete_no_227206994")
+        choose("activity_is_complete_no_#{activity.id}")
         fill_in "activity[noncompliance_reason]", with: "ate cheeseburgers instead"
         click_on "Next"
+
+        expect("Activity Saved")
       end
     end
   end

--- a/spec/fixtures/activities.yml
+++ b/spec/fixtures/activities.yml
@@ -44,7 +44,6 @@ planned_activity_today_2:
   participant: participant4
   activity_type: commuting
   is_scheduled: true
-  is_complete: true
   start_time: <%= DateTime.current.advance(hours: -1) %>
   end_time: <%= DateTime.current %>
 
@@ -54,7 +53,6 @@ planned_activity_today_3:
   predicted_accomplishment_intensity: 9
   predicted_pleasure_intensity: 1
   is_scheduled: true
-  is_complete: true
   start_time: <%= DateTime.current %>
   end_time: <%= DateTime.current.advance(hours: 1) %>
 
@@ -70,7 +68,6 @@ planned_activity_today_4:
 p2_planned_activity_3_hrs_ago:
   participant: traveling_participant1
   activity_type: eating
-  is_complete: true
   is_scheduled: true
   is_reviewed: true
   predicted_accomplishment_intensity: 10
@@ -83,7 +80,6 @@ p2_planned_activity_3_hrs_ago:
 p2_planned_activity_2_hrs_ago:
   participant: traveling_participant1
   activity_type: working
-  is_complete: true
   is_scheduled: true
   is_reviewed: true
   predicted_accomplishment_intensity: 1
@@ -108,7 +104,6 @@ p2_activity_previous_day:
   predicted_pleasure_intensity: 2
   actual_accomplishment_intensity: 6
   actual_pleasure_intensity: 7
-  is_complete: true
   is_scheduled: true
   start_time: <%= Time.now - 315.hours %>
   end_time: <%= Time.now - 314.hours %>
@@ -125,7 +120,6 @@ p2_activity_next_day:
 p3_planned_activity_at_9:
   participant: traveling_participant2
   activity_type: working
-  is_complete: true
   is_scheduled: true
   predicted_accomplishment_intensity: 1
   predicted_pleasure_intensity: 1
@@ -135,7 +129,6 @@ p3_planned_activity_at_9:
 p3_planned_activity_at_10:
   participant: traveling_participant2
   activity_type: working
-  is_complete: true
   is_scheduled: true
   predicted_accomplishment_intensity: 1
   predicted_pleasure_intensity: 1

--- a/spec/fixtures/activities.yml
+++ b/spec/fixtures/activities.yml
@@ -14,6 +14,14 @@ unplanned_activity4:
   participant: participant1
   activity_type: loving
 
+planned_activity0:
+  participant: participant1
+  activity_type: loving
+  predicted_accomplishment_intensity: 3
+  predicted_pleasure_intensity: 1
+  start_time: <%= DateTime.current.advance(hours: -4) %>
+  end_time: <%= DateTime.current.advance(hours: -3) %>
+
 planned_activity1:
   participant: participant1
   activity_type: loving
@@ -64,6 +72,7 @@ p2_planned_activity_3_hrs_ago:
   activity_type: eating
   is_complete: true
   is_scheduled: true
+  is_reviewed: true
   predicted_accomplishment_intensity: 10
   predicted_pleasure_intensity: 10
   actual_accomplishment_intensity: 9
@@ -76,6 +85,7 @@ p2_planned_activity_2_hrs_ago:
   activity_type: working
   is_complete: true
   is_scheduled: true
+  is_reviewed: true
   predicted_accomplishment_intensity: 1
   predicted_pleasure_intensity: 1
   actual_accomplishment_intensity: 2


### PR DESCRIPTION
Update Terminology of IsComplete and Complete

* The validation on the activity's ```is_complete```  
  is removed because this column will be dropped.
* Remove ```complete``` method from views and models.
* Update ```complete``` scope to ```reviewed_and_complete```.
* Remove ```is_complete``` from forms and ```params```.
* Migration drops ```is_complete``` column from activities table.
* In activity views (content_providers) for participants,  
  change ```incomplete``` to ```planned```.

[#89044666]