### PR TITLE
Make lesson pages more printable

### DIFF
--- a/app/assets/stylesheets/think_feel_do_engine/print.css.scss
+++ b/app/assets/stylesheets/think_feel_do_engine/print.css.scss
@@ -2,16 +2,9 @@
   position: inherit !important;
   height: inherit !important;
 }
-@page
-{
-  size: auto;
-  margin: 25mm 25mm 25mm 25mm;
-}
 
-body {
-  overflow: visible;
+.container { width: 100%; }
 
-  div {
-    display: inline;
-  }
+.tool-content {
+  display: inline;
 }

--- a/app/assets/stylesheets/think_feel_do_engine/print.css.scss
+++ b/app/assets/stylesheets/think_feel_do_engine/print.css.scss
@@ -2,3 +2,16 @@
   position: inherit !important;
   height: inherit !important;
 }
+@page
+{
+  size: auto;
+  margin: 25mm 25mm 25mm 25mm;
+}
+
+body {
+  overflow: visible;
+
+  div {
+    display: inline;
+  }
+}

--- a/app/views/think_feel_do_engine/lessons/_lesson.html.erb
+++ b/app/views/think_feel_do_engine/lessons/_lesson.html.erb
@@ -1,5 +1,6 @@
+<% stylesheet_link_tag 'print', :media => 'print' %>
+
 <h3><%= lesson.pretty_title %></h3>
 
 <h4><a href="javascript:window.print()" class="hidden-print">Print</a> | <%= link_to "Return to Lessons", think_feel_do_engine.navigator_context_path(context_name: current_participant.current_group.arm.bit_core_tools.find_by_type("Tools::Learn").title) %></h4>
-
-<%= render partial: "think_feel_do_engine/slides/slide", collection: lesson.slides %>
+<%= render partial: "think_feel_do_engine/slides/slide", collection: lesson.slides, layout: "printable" %>

--- a/app/views/think_feel_do_engine/participants/lessons/_printable.html.erb
+++ b/app/views/think_feel_do_engine/participants/lessons/_printable.html.erb
@@ -1,0 +1,15 @@
+<% slide = slide || @slide %>
+<div class="tool-content">
+  <% if slide.is_title_visible %>
+    <div class="slide">
+      <h1><%= slide.title %></h1>
+    </div>
+  <% end %>
+
+  <% case slide.class.to_s %>
+  <% when 'BitCore::VideoSlide' || 'BitCore::AudioSlide' %>
+    <%= slide.options['url'].to_s %>
+    [ Not shown - multimedia file] <br><br>
+  <% end %>
+  <%= slide.render_body %>
+</div>


### PR DESCRIPTION

* Create custom printable template for lessons
  with pared-down formatting
* In printable template, replace multimedia with
  a text placeholder
* Add inline attribute to all divs in print.css to
  prevent content from getting cut off
* Override bootstrap container for Firefox

[#88866314]