### PR TITLE
Remove Is Scheduled

### DIFF
--- a/app/helpers/think_feel_do_engine/activities_helper.rb
+++ b/app/helpers/think_feel_do_engine/activities_helper.rb
@@ -15,5 +15,28 @@ module ThinkFeelDoEngine
       end
       count == 0 ? "No activities exist." : total_diff.to_f / count
     end
+
+    def percent_complete_message(activities)
+      "Completion Score: #{percent_complete(activities)}% "\
+      "(You completed "\
+      "#{activities.reviewed_and_complete.count} "\
+      "out of #{scheduled_message(activities.were_planned)} "\
+      "that you scheduled.)"
+    end
+
+    def percent_complete(activities)
+      (
+        activities.reviewed_and_complete.count.to_f /
+        (activities.were_planned.count).to_f * 100
+      ).round(0)
+    end
+
+    def scheduled_count(activities)
+      activities.were_planned.count
+    end
+
+    def scheduled_message(activities)
+      pluralize(scheduled_count(activities), "activity")
+    end
   end
 end

--- a/app/helpers/think_feel_do_engine/activities_helper.rb
+++ b/app/helpers/think_feel_do_engine/activities_helper.rb
@@ -17,11 +17,15 @@ module ThinkFeelDoEngine
     end
 
     def percent_complete_message(activities)
-      "Completion Score: #{percent_complete(activities)}% "\
-      "(You completed "\
-      "#{activities.reviewed_and_complete.count} "\
-      "out of #{scheduled_message(activities.were_planned)} "\
-      "that you scheduled.)"
+      if activities.count > 0
+        "Completion Score: #{percent_complete(activities)}% "\
+        "(You completed "\
+        "#{activities.reviewed_and_complete.count} "\
+        "out of #{scheduled_message(activities.were_planned)} "\
+        "that you scheduled.)"
+      else
+        "Completion Score: Not Available (No activities were scheduled.)"
+      end
     end
 
     def percent_complete(activities)

--- a/app/models/activity.rb
+++ b/app/models/activity.rb
@@ -52,9 +52,6 @@ class Activity < ActiveRecord::Base
     ).in_the_past
   }
 
-  # To Do: fix naming and/or what is going on here
-  # change to start_time and is_scheduled
-  # and updated tests
   scope :unscheduled_or_in_the_future, lambda {
     where(
       arel_table[:start_time].eq(nil)
@@ -72,9 +69,6 @@ class Activity < ActiveRecord::Base
         actual_pleasure_intensity: nil)
   }
 
-  # To Do: fix naming and/or what is going on here
-  # change to start_time
-  # and updated tests
   scope :in_the_future, lambda {
     where(
       arel_table[:end_time].gt(Time.current)
@@ -96,8 +90,11 @@ class Activity < ActiveRecord::Base
     order("RANDOM()")
   }
 
-  scope :scheduled, lambda {
-    where(is_scheduled: true)
+  scope :were_planned, lambda {
+    where
+      .not(
+        predicted_accomplishment_intensity: nil,
+        predicted_pleasure_intensity: nil)
   }
 
   scope :unplanned, lambda {

--- a/app/models/content_providers/create_activity.rb
+++ b/app/models/content_providers/create_activity.rb
@@ -18,8 +18,7 @@ module ContentProviders
         :activity_type_new_title,
         :predicted_pleasure_intensity,
         :predicted_accomplishment_intensity,
-        :start_time,
-        :is_scheduled
+        :start_time
       ]
     end
 

--- a/app/models/content_providers/fun_activity_checklist.rb
+++ b/app/models/content_providers/fun_activity_checklist.rb
@@ -18,8 +18,7 @@ module ContentProviders
         :activity_type_new_title,
         :predicted_pleasure_intensity,
         :predicted_accomplishment_intensity,
-        :start_time,
-        :is_scheduled
+        :start_time
       ]
     end
 

--- a/app/models/content_providers/important_activity_checklist.rb
+++ b/app/models/content_providers/important_activity_checklist.rb
@@ -19,8 +19,7 @@ module ContentProviders
         :activity_type_new_title,
         :predicted_pleasure_intensity,
         :predicted_accomplishment_intensity,
-        :start_time,
-        :is_scheduled
+        :start_time
       ]
     end
 

--- a/app/views/think_feel_do_engine/activities/_build_activity.html.erb
+++ b/app/views/think_feel_do_engine/activities/_build_activity.html.erb
@@ -1,5 +1,4 @@
 <%= form_for current_participant.activities.build, url: create_path, method: "post", html: { role: "form", class: "activity_form", id: "activity-form"} do |f| %>
-  <input class="not-displayed" name="activity[is_scheduled]" value="1">
 
   <% if past_activities.count > 0 %>
     <label>Choose one</label>

--- a/app/views/think_feel_do_engine/activities/_daily_summary.html.erb
+++ b/app/views/think_feel_do_engine/activities/_daily_summary.html.erb
@@ -25,8 +25,7 @@
           you recorded is both high pleasure and high accomplishment.
         </p>
         <p>
-          Completion Score: <%= activities.scheduled.completion_score %>%
-          (You completed <%= activities.scheduled.reviewed_and_complete.count %> out of <%= pluralize(activities.scheduled.count, 'activity') %> that you scheduled.)
+          <%= percent_complete_message(activities) %>
         <p>
         <p>
           <strong>Average Accomplishment Discrepancy:</strong> <%= average_intensity_difference(activities.reviewed_and_complete, :accomplishment) %>

--- a/db/migrate/20150302155709_remove_is_scheduled_from_activities.rb
+++ b/db/migrate/20150302155709_remove_is_scheduled_from_activities.rb
@@ -1,0 +1,5 @@
+class RemoveIsScheduledFromActivities < ActiveRecord::Migration
+  def change
+    remove_column :activities, :is_scheduled, :boolean, default: false, null: false
+  end
+end

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150227221640) do
+ActiveRecord::Schema.define(version: 20150302155709) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -28,7 +28,6 @@ ActiveRecord::Schema.define(version: 20150227221640) do
     t.text     "noncompliance_reason"
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.boolean  "is_scheduled",                       default: false, null: false
     t.boolean  "is_reviewed",                        default: false, null: false
   end
 

--- a/spec/features/participant/activities/content_providers/your_activities_provider_spec.rb
+++ b/spec/features/participant/activities/content_providers/your_activities_provider_spec.rb
@@ -62,10 +62,10 @@ feature "Activities", type: :feature do
         end
 
         it "displays daily completion information of only scheduled activities" do
-          scheduled_activities = participant.activities.for_day(Time.now).scheduled
+          reviewed_and_complete = participant.activities.for_day(Time.now).reviewed_and_complete
+          were_planned = participant.activities.for_day(Time.now).were_planned
 
-          expect(scheduled_activities.count).to eq 2
-          expect(page).to have_text "Completion Score: 100% (You completed 2 out of 2 activities that you scheduled.)"
+          expect(page).to have_text "Completion Score: 67% (You completed #{reviewed_and_complete.count} out of #{were_planned.count} activities that you scheduled.)"
         end
 
         it "navigates to today when 'Today' button is clicked" do

--- a/spec/fixtures/activities.yml
+++ b/spec/fixtures/activities.yml
@@ -26,7 +26,6 @@ planned_activity1:
   participant: participant1
   activity_type: loving
   actual_pleasure_intensity: 6
-  is_scheduled: true
   start_time: <%= DateTime.current.advance(hours: -2) %>
   end_time: <%= DateTime.current.advance(hours: -1) %>
 
@@ -43,7 +42,6 @@ planned_activity_today_1:
 planned_activity_today_2:
   participant: participant4
   activity_type: commuting
-  is_scheduled: true
   start_time: <%= DateTime.current.advance(hours: -1) %>
   end_time: <%= DateTime.current %>
 
@@ -52,7 +50,6 @@ planned_activity_today_3:
   activity_type: commuting
   predicted_accomplishment_intensity: 9
   predicted_pleasure_intensity: 1
-  is_scheduled: true
   start_time: <%= DateTime.current %>
   end_time: <%= DateTime.current.advance(hours: 1) %>
 
@@ -61,14 +58,12 @@ planned_activity_today_4:
   activity_type: working
   predicted_accomplishment_intensity: 4
   predicted_pleasure_intensity: 5
-  is_scheduled: true
   start_time: <%= DateTime.current.advance(hours: 1) %>
   end_time: <%= DateTime.current.advance(hours: 2) %>
 
 p2_planned_activity_3_hrs_ago:
   participant: traveling_participant1
   activity_type: eating
-  is_scheduled: true
   is_reviewed: true
   predicted_accomplishment_intensity: 10
   predicted_pleasure_intensity: 10
@@ -80,7 +75,6 @@ p2_planned_activity_3_hrs_ago:
 p2_planned_activity_2_hrs_ago:
   participant: traveling_participant1
   activity_type: working
-  is_scheduled: true
   is_reviewed: true
   predicted_accomplishment_intensity: 1
   predicted_pleasure_intensity: 1
@@ -104,14 +98,12 @@ p2_activity_previous_day:
   predicted_pleasure_intensity: 2
   actual_accomplishment_intensity: 6
   actual_pleasure_intensity: 7
-  is_scheduled: true
   start_time: <%= Time.now - 315.hours %>
   end_time: <%= Time.now - 314.hours %>
 
 p2_activity_next_day:
   participant: traveling_participant1
   activity_type: commuting
-  is_scheduled: true
   predicted_accomplishment_intensity: 8
   predicted_pleasure_intensity: 4
   start_time: <%= Time.now - 265.hours %>
@@ -120,7 +112,6 @@ p2_activity_next_day:
 p3_planned_activity_at_9:
   participant: traveling_participant2
   activity_type: working
-  is_scheduled: true
   predicted_accomplishment_intensity: 1
   predicted_pleasure_intensity: 1
   start_time: <%= Time.now - 286.hours %>
@@ -129,7 +120,6 @@ p3_planned_activity_at_9:
 p3_planned_activity_at_10:
   participant: traveling_participant2
   activity_type: working
-  is_scheduled: true
   predicted_accomplishment_intensity: 1
   predicted_pleasure_intensity: 1
   start_time: <%= Time.now - 285.hours %>

--- a/spec/helpers/think_feel_do_engine/activities_helper_spec.rb
+++ b/spec/helpers/think_feel_do_engine/activities_helper_spec.rb
@@ -2,9 +2,16 @@ require "rails_helper"
 
 module ThinkFeelDoEngine
   RSpec.describe ActivitiesHelper, type: :helper do
+    fixtures :participants, :activity_types
+
     def activity(attrs)
       Activity.new(actual_pleasure_intensity: attrs[:actual],
-                   predicted_pleasure_intensity: attrs[:predicted])
+                   predicted_pleasure_intensity: attrs[:predicted],
+                   actual_accomplishment_intensity: attrs[:actual_accomplishment],
+                   predicted_accomplishment_intensity: attrs[:predicted_accomplishment],
+                   is_reviewed: attrs[:is_reviewed] || false,
+                   participant: participants(:participant1),
+                   activity_type: activity_types(:jogging))
     end
 
     describe "#average_intensity_difference" do
@@ -33,6 +40,43 @@ module ThinkFeelDoEngine
         ].each do |activities|
           expect(helper.average_intensity_difference(activities, "pleasure"))
             .to eq 0
+        end
+      end
+    end
+
+    describe "daily summary information" do
+      before :each do
+        activity(predicted: 1, predicted_accomplishment: 4).save
+        activity(
+          predicted: 1,
+          predicted_accomplishment: 4,
+          actual: 1,
+          actual_accomplishment: 4,
+          is_reviewed: true
+        ).save
+      end
+
+      describe "percent_complete_message" do
+        it "returns a message detailing percent complete" do
+          expect(percent_complete_message(Activity)).to eq "Completion Score: 50% (You completed 1 out of 2 activities that you scheduled.)"
+        end
+      end
+
+      describe "percent_complete" do
+        it "to return a integer of how many activities were reviewed_and_completed out of how many were planned" do
+          expect(percent_complete(Activity)).to eq 50
+        end
+      end
+
+      describe "scheduled_count" do
+        it "returns a total count of activities 'planned' and 'reviewed and completed'" do
+          expect(scheduled_count(Activity)).to eq 2
+        end
+      end
+
+      describe "scheduled_message" do
+        it "returns the pluralized version of 'activity' depending on the count" do
+          expect(scheduled_message(Activity)).to eq "2 activities"
         end
       end
     end

--- a/spec/helpers/think_feel_do_engine/activities_helper_spec.rb
+++ b/spec/helpers/think_feel_do_engine/activities_helper_spec.rb
@@ -44,39 +44,49 @@ module ThinkFeelDoEngine
       end
     end
 
-    describe "daily summary information" do
-      before :each do
-        activity(predicted: 1, predicted_accomplishment: 4).save
-        activity(
-          predicted: 1,
-          predicted_accomplishment: 4,
-          actual: 1,
-          actual_accomplishment: 4,
-          is_reviewed: true
-        ).save
-      end
-
+    describe "no activities exist" do
       describe "percent_complete_message" do
-        it "returns a message detailing percent complete" do
-          expect(percent_complete_message(Activity)).to eq "Completion Score: 50% (You completed 1 out of 2 activities that you scheduled.)"
+        it "returns 'NA' in the message if no activities were scheduled" do
+          expect(percent_complete_message(Activity)).to eq "Completion Score: Not Available (No activities were scheduled.)"
         end
       end
+    end
 
-      describe "percent_complete" do
-        it "to return a integer of how many activities were reviewed_and_completed out of how many were planned" do
-          expect(percent_complete(Activity)).to eq 50
+    describe "activities exist" do
+      describe "daily summary information" do
+        before :each do
+          activity(predicted: 1, predicted_accomplishment: 4).save
+          activity(
+            predicted: 1,
+            predicted_accomplishment: 4,
+            actual: 1,
+            actual_accomplishment: 4,
+            is_reviewed: true
+          ).save
         end
-      end
 
-      describe "scheduled_count" do
-        it "returns a total count of activities 'planned' and 'reviewed and completed'" do
-          expect(scheduled_count(Activity)).to eq 2
+        describe "percent_complete_message" do
+          it "returns a message detailing percent complete" do
+            expect(percent_complete_message(Activity)).to eq "Completion Score: 50% (You completed 1 out of 2 activities that you scheduled.)"
+          end
         end
-      end
 
-      describe "scheduled_message" do
-        it "returns the pluralized version of 'activity' depending on the count" do
-          expect(scheduled_message(Activity)).to eq "2 activities"
+        describe "percent_complete" do
+          it "to return a integer of how many activities were reviewed_and_completed out of how many were planned" do
+            expect(percent_complete(Activity)).to eq 50
+          end
+        end
+
+        describe "scheduled_count" do
+          it "returns a total count of activities 'planned' and 'reviewed and completed'" do
+            expect(scheduled_count(Activity)).to eq 2
+          end
+        end
+
+        describe "scheduled_message" do
+          it "returns the pluralized version of 'activity' depending on the count" do
+            expect(scheduled_message(Activity)).to eq "2 activities"
+          end
         end
       end
     end

--- a/spec/models/activity_spec.rb
+++ b/spec/models/activity_spec.rb
@@ -152,13 +152,25 @@ RSpec.describe Activity do
       end
     end
 
-    describe ".scheduled" do
-      it "returns activities where is_scheduled is true" do
-        scheduled_activities = Activity.scheduled
+    describe ".planned" do
+      it "returns activities have neither actual intensity rated and both predicted intensities rated" do
+        planned_activities = Activity.planned
 
-        expect(scheduled_activities.load).not_to be_empty
-        scheduled_activities.each do |a|
-          expect(a.is_scheduled).to eq true
+        expect(planned_activities.load).not_to be_empty
+        planned_activities.each do |a|
+          expect(a.planned?).to eq true
+        end
+      end
+    end
+
+    describe ".were_planned" do
+      it "returns activities where both predicted intensities were rated" do
+        were_planned = Activity.were_planned
+
+        expect(were_planned.load).not_to be_empty
+        were_planned.each do |a|
+          expect(a.predicted_pleasure_intensity).to_not eq nil
+          expect(a.predicted_accomplishment_intensity).to_not eq nil
         end
       end
     end


### PR DESCRIPTION
Remove Is Scheduled

* Add helper compute percents and display message dealing with  
  the number of reviwed & completed activities relative the number  
  of activities that were at one time planned.
* Add helper specs.
* Add scope ```were_planned``` to query all activities that were  
  at one time planned.
* Update providers by removing ```is_scheduled``` from parameters.
* Add migration to drop ```is_scheduled``` from activities table.
* Update activity fixtures to reflect removal of ```is_scheduled```.

[#89418002, #89044666]