### PR TITLE
Update Activity Viz with Rated Activities

### DIFF
--- a/app/assets/javascripts/think_feel_do_engine/activities/daily_breakdown.js
+++ b/app/assets/javascripts/think_feel_do_engine/activities/daily_breakdown.js
@@ -380,7 +380,6 @@
       d.predicted_accomplishment = (d.predicted_accomplishment_intensity !== null ? d.predicted_accomplishment_intensity : -1);
       d.actual_pleasure = (d.actual_pleasure_intensity !== null ? d.actual_pleasure_intensity : -1);
       d.actual_accomplishment = (d.actual_accomplishment_intensity !== null ? d.actual_accomplishment_intensity : -1);
-      d.completed = d.is_complete === true;
       d.start_date = parse_time(new Date(d.start_datetime));
       d.bucket = getBucket(d.actual_pleasure, d.actual_accomplishment);
       if (!isNaN(d.start_datetime) && !isNaN(d.end_datetime)) {

--- a/app/models/activity.rb
+++ b/app/models/activity.rb
@@ -97,6 +97,13 @@ class Activity < ActiveRecord::Base
         predicted_pleasure_intensity: nil)
   }
 
+  scope :with_actual_ratings, lambda {
+    where
+      .not(
+        actual_accomplishment_intensity: nil,
+        actual_pleasure_intensity: nil)
+  }
+
   scope :unplanned, lambda {
     where(start_time: nil, end_time: nil)
   }

--- a/app/models/content_providers/your_activities_provider.rb
+++ b/app/models/content_providers/your_activities_provider.rb
@@ -11,7 +11,7 @@ module ContentProviders
           moods: moods(options),
           negative_emotions: negative_emotions(options),
           positive_emotions: positive_emotions(options),
-          completed_week_activities: completed_week_activities(options),
+          with_actual_ratings: with_actual_ratings(options),
           dates_with_activities:  collect_dates_with_activities(options)
         }
       )
@@ -57,12 +57,12 @@ module ContentProviders
         .for_day(local_time(options))
     end
 
-    def completed_week_activities(options)
+    def with_actual_ratings(options)
       options
         .participant
         .activities
         .last_seven_days
-        .reviewed_and_complete
+        .with_actual_ratings
         .order(start_time: :asc)
     end
 

--- a/app/views/think_feel_do_engine/activities/visualization.html.erb
+++ b/app/views/think_feel_do_engine/activities/visualization.html.erb
@@ -113,7 +113,7 @@
       $("#activities").remove();
       $("#datepicker").hide();
       numOfDays = $(event.currentTarget).data("range");
-      dailyBreakdown(<%= completed_week_activities.to_json(methods: :title).html_safe %>, numOfDays);
+      dailyBreakdown(<%= with_actual_ratings.to_json(methods: :title).html_safe %>, numOfDays);
     })
   });
 </script>

--- a/spec/models/activity_spec.rb
+++ b/spec/models/activity_spec.rb
@@ -28,6 +28,16 @@ RSpec.describe Activity do
       end
     end
 
+    describe ".with_actual_ratings" do
+      it "returns all activities that have actual intensity ratings" do
+        expect do
+          sleeping(
+            actual_accomplishment_intensity: 5,
+            actual_pleasure_intensity: 5)
+        end.to change { Activity.with_actual_ratings.count }.by(1)
+      end
+    end
+
     describe ".reviewed_and_complete" do
       it "returns all activities that have been reviewed and have predicted intensities, acutal intensities, and it was reviewed" do
         expect do


### PR DESCRIPTION
Update Activity Viz with Rated Activities

* Activity viz now displays activities that have actual rating  
  intensities - whether or not they were reviewed or not or  
  whether or not they have predicted ratings.
* Scope for quering activities with actual ratings.
* Rspec test for scope.
* Update provider with new scope.

[Finishes: #89419254]