### PR TITLE
Msw set is reviewed

### DIFF
--- a/app/models/content_providers/past_activity_review_form.rb
+++ b/app/models/content_providers/past_activity_review_form.rb
@@ -25,7 +25,7 @@ module ContentProviders
     def data_attributes
       [
         :id, :actual_pleasure_intensity, :actual_accomplishment_intensity,
-        :noncompliance_reason
+        :noncompliance_reason, :is_reviewed
       ]
     end
 

--- a/app/views/think_feel_do_engine/activities/past_activity_review.html.erb
+++ b/app/views/think_feel_do_engine/activities/past_activity_review.html.erb
@@ -23,7 +23,7 @@
       <strong>Did you?</strong>
 
       <div class="btn-group" data-toggle="buttons">
-        <label class="btn btn-success active">
+        <label class="btn btn-success">
           <%= content_tag(:input, "Yes", class: "radio_yes", :'data-activity-id' => "#{activity.id}", id: "activity_is_complete_yes_#{activity.id}", name: "activity[is_complete]", type: "radio", value: "true") %>
         </label>
         <label class="btn btn-danger">

--- a/app/views/think_feel_do_engine/activities/past_activity_review.html.erb
+++ b/app/views/think_feel_do_engine/activities/past_activity_review.html.erb
@@ -14,6 +14,7 @@
           }
         ) do |f| %>
       <%= f.hidden_field :id, { value: activity.id } %>
+      <%= f.hidden_field :is_reviewed, { value: true } %>
 
       <h2>You said you were going to</h2>
 

--- a/spec/features/participant/activities/content_providers/past_activity_review_form_spec.rb
+++ b/spec/features/participant/activities/content_providers/past_activity_review_form_spec.rb
@@ -15,20 +15,32 @@ feature "Activities", type: :feature do
       end
 
       scenario "Participant reviews an activity they completed" do
+        expect(activity.is_reviewed).to eq false
+
         choose("activity_is_complete_yes_#{activity.id}")
         select 9, from: "activity[actual_accomplishment_intensity]"
         select 4, from: "activity[actual_pleasure_intensity]"
         click_on "Next"
 
         expect("Activity Saved")
+
+        activity.reload
+
+        expect(activity.is_reviewed).to eq true
       end
 
       scenario "Participant reviews an activity they did not complete" do
+        expect(activity.is_reviewed).to eq false
+
         choose("activity_is_complete_no_#{activity.id}")
         fill_in "activity[noncompliance_reason]", with: "ate cheeseburgers instead"
         click_on "Next"
 
         expect("Activity Saved")
+
+        activity.reload
+
+        expect(activity.is_reviewed).to eq true
       end
     end
   end


### PR DESCRIPTION
Set Review Attribute
* Past Activity Review Form Provider sets ```is_reviewed``` to true.
* Update tests to verify ```is_reviewed``` is being set.
* Active state class is removed from  
  Past Activity Review From Provider b/c  
  I accidentally added it in a while back  
  even though form wasn't visible.

[Finishes: #89419192]