### PR TITLE
Prevent Actual Ratings From Being Set

### DIFF
--- a/app/assets/javascripts/think_feel_do_engine/activities/forms.js
+++ b/app/assets/javascripts/think_feel_do_engine/activities/forms.js
@@ -55,9 +55,15 @@
 
         if (val === 'true') {
           $('#activity-incomplete-' + id).hide();
-          $('#activity-complete-' + id).show();
+          $('#activity-complete-' + id)
+          .show()
+          .find('select#activity_actual_accomplishment_intensity, select#activity_actual_pleasure_intensity')
+            .removeAttr("disabled")
         } else {
-          $('#activity-complete-' + id).hide();
+          $('#activity-complete-' + id)
+          .hide()
+          .find('select#activity_actual_accomplishment_intensity, select#activity_actual_pleasure_intensity')
+            .attr("disabled", "disabled");
           $('#activity-incomplete-' + id).show();
         }
 

--- a/app/views/think_feel_do_engine/shared/_rating_selector.html.erb
+++ b/app/views/think_feel_do_engine/shared/_rating_selector.html.erb
@@ -1,7 +1,7 @@
 <%= form.label name, label, for: "#{ name }_#{ object.id }" %><br>
 
 <div class="form-group">
-  <select id="<%= prefix %>[<%= name %>]" name="<%= prefix %>[<%= name %>]" class="form-control">
+  <select id="<%= prefix %>_<%= name %>" name="<%= prefix %>[<%= name %>]" class="form-control">
     <% (0..10).each do |value| %>
       <option value="<%= value %>">
         <% if value == 0 || value == 5 || value == 10 %>

--- a/spec/features/participant/activities/content_providers/past_activity_review_form_spec.rb
+++ b/spec/features/participant/activities/content_providers/past_activity_review_form_spec.rb
@@ -42,6 +42,26 @@ feature "Activities", type: :feature do
 
         expect(activity.is_reviewed).to eq true
       end
+
+      scenario "Participant reviews an activity they did not complete and actual intensities are not set", :js do
+        expect(activity.actual_accomplishment_intensity).to be_nil
+        expect(activity.actual_pleasure_intensity).to be_nil
+
+        execute_script %{
+          $("input#activity_is_complete_no_#{activity.id}").trigger('click');
+        }
+        fill_in "activity[noncompliance_reason]", with: "ate cheeseburgers instead"
+
+        click_on "Next"
+
+        expect(page).to have_text "Activity saved"
+        expect(page).to have_text "Good Work!"
+
+        activity.reload
+
+        expect(activity.actual_accomplishment_intensity).to be_nil
+        expect(activity.actual_pleasure_intensity).to be_nil
+      end
     end
   end
 end


### PR DESCRIPTION
Prevent Actual Ratings From Being Set

* Prevent Past Activity Review From activities'  
  actual ratings from being set if the  
  participant selects 'noncompliance'.

[Finishes: #89544910]