### PR TITLE
Msw edit activities

### DIFF
--- a/app/controllers/think_feel_do_engine/participants/activities_controller.rb
+++ b/app/controllers/think_feel_do_engine/participants/activities_controller.rb
@@ -13,13 +13,16 @@ module ThinkFeelDoEngine
       # ...
 
       def update
-        if @activity.update(activity_params_for_update)
+        if @activity.update_as_reviewed(activity_params_for_update)
+          flash[:notice] = "Activity updated."
           respond_to do |format|
             format.js { render inline: "Turbolinks.visit(window.location);" }
           end
         else
-          flash.now[:alert] = @activity.errors.full_messages.join(", ")
-          render :edit
+          flash[:alert] = @activity.errors.full_messages.join(", ")
+          respond_to do |format|
+            format.js { render inline: "Turbolinks.visit(window.location);" }
+          end
         end
       end
 

--- a/app/models/activity.rb
+++ b/app/models/activity.rb
@@ -127,7 +127,7 @@ class Activity < ActiveRecord::Base
   end
 
   def actual_editable?
-    if end_time
+    if end_time && !reviewed_and_incomplete?
       end_time < Time.zone.now
     else
       false

--- a/app/models/activity.rb
+++ b/app/models/activity.rb
@@ -120,6 +120,12 @@ class Activity < ActiveRecord::Base
     super + %w(activity_type_title activity_type_new_title)
   end
 
+  def update_as_reviewed(params = {})
+    update(
+      params
+      .merge(is_reviewed: true))
+  end
+
   def actual_editable?
     if end_time
       end_time < Time.zone.now

--- a/spec/controllers/think_feel_do_engine/participants/activities_controller_spec.rb
+++ b/spec/controllers/think_feel_do_engine/participants/activities_controller_spec.rb
@@ -1,0 +1,58 @@
+require "rails_helper"
+
+module ThinkFeelDoEngine
+  module Participants
+    RSpec.describe ActivitiesController, type: :controller do
+      describe "PUT update" do
+        let(:activity) { double("activity") }
+        let(:participant) { double("participant") }
+
+        context "activity updates with update_as_reviewed" do
+          before do
+            sign_in_participant participant
+            allow(participant).to receive(:activities) { Activity }
+            allow(Activity).to receive(:find) { activity }
+            allow(activity).to receive(:update_as_reviewed) { true }
+            put :update,
+                id: 1,
+                activity: {
+                  actual_accomplishment_intensity: 1,
+                  actual_pleasure_intensity: 4
+                },
+                use_route: :think_feel_do_engine,
+                format: :js
+          end
+
+          it "responds with js and visits the current page with success notice" do
+            expect(flash[:notice]).to be_present
+            expect(response.body).to eq "Turbolinks.visit(window.location);"
+          end
+        end
+
+        context "activity does not update with update_as_reviewed" do
+          before do
+            sign_in_participant participant
+            allow(participant).to receive(:activities) { Activity }
+            allow(Activity).to receive(:find) { activity }
+            allow(activity).to receive(:update_as_reviewed) { false }
+            allow(activity)
+              .to receive_message_chain(:errors, :full_messages) { ["Errors"] }
+            put :update,
+                id: 1,
+                activity: {
+                  actual_accomplishment_intensity: 1,
+                  actual_pleasure_intensity: 4
+                },
+                use_route: :think_feel_do_engine,
+                format: :js
+          end
+
+          it "responds with js and visits the current page with a error alert" do
+            expect(flash[:alert]).to be_present
+            expect(response.body).to eq "Turbolinks.visit(window.location);"
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/features/participant/activities/content_providers/your_activities_provider_spec.rb
+++ b/spec/features/participant/activities/content_providers/your_activities_provider_spec.rb
@@ -120,6 +120,7 @@ feature "Activities", type: :feature do
             execute_script("$('.panel-footer input.btn-primary').trigger('click')")
           end
 
+          expect(page).to have_text "Activity updated"
           expect(page).to have_text "Accomplishment: 0 · Pleasure: 0"
 
           page.all("a", text: "Working")[1].click

--- a/spec/models/activity_spec.rb
+++ b/spec/models/activity_spec.rb
@@ -188,20 +188,46 @@ RSpec.describe Activity do
 
   describe "instance methods" do
     describe "#update_as_reviewed" do
-      let(:running) do
-        Activity.new(
-          participant: participants(:participant1),
-          activity_type: activity_types(:jogging)
-        )
-      end
+      let(:activity) { activities(:planned_activity0) }
 
       it "updates activity with is_reviewed to be true" do
-        expect(running.is_reviewed).to eq false
+        expect(activity.is_reviewed).to eq false
 
-        running.update_as_reviewed
-        running.reload
+        activity.update_as_reviewed
 
-        expect(running.is_reviewed).to eq true
+        expect(activity.is_reviewed).to eq true
+      end
+
+      it "returns false if actual_accomplishment_intensity is nil" do
+        activity.update_as_reviewed
+
+        expect(activity).to_not be_valid
+      end
+
+      it "returns error messages if actual_accomplishment_intensity is nil" do
+        activity.update_as_reviewed
+
+        expect(
+          activity
+          .errors
+          .full_messages
+        ).to include("Actual accomplishment intensity can't be blank.")
+      end
+
+      it "returns false if actual_pleasure_intensity is nil" do
+        activity.update_as_reviewed
+
+        expect(activity).to_not be_valid
+      end
+
+      it "returns error messages if actual_accomplishment_intensity is nil" do
+        activity.update_as_reviewed
+
+        expect(
+          activity
+          .errors
+          .full_messages
+        ).to include("Actual pleasure intensity can't be blank.")
       end
     end
 

--- a/spec/models/activity_spec.rb
+++ b/spec/models/activity_spec.rb
@@ -187,6 +187,24 @@ RSpec.describe Activity do
   end
 
   describe "instance methods" do
+    describe "#update_as_reviewed" do
+      let(:running) do
+        Activity.new(
+          participant: participants(:participant1),
+          activity_type: activity_types(:jogging)
+        )
+      end
+
+      it "updates activity with is_reviewed to be true" do
+        expect(running.is_reviewed).to eq false
+
+        running.update_as_reviewed
+        running.reload
+
+        expect(running.is_reviewed).to eq true
+      end
+    end
+
     describe "#monitored?" do
       def running(attributes = {})
         Activity.create!({

--- a/spec/models/activity_spec.rb
+++ b/spec/models/activity_spec.rb
@@ -392,6 +392,12 @@ RSpec.describe Activity do
       it "returns false without an end_time" do
         expect(activities(:unplanned_activity1)).not_to be_actual_editable
       end
+
+      it "returns false if the activity has been reviewed and is incomplete" do
+        allow(activity).to receive(:reviewed_and_incomplete?).and_return(true)
+
+        expect(activity).not_to be_actual_editable
+      end
     end
 
     describe "#intensity_difference" do


### PR DESCRIPTION
Automatically Review Activities & Update Editability

* When a participant updates an activity from  
  the 'Your Activities' page, the activity is  
  automatically reviewed.
* Model test for ```update_as_reviewed```.
* Controller spec for success and errors.
* On the 'Your Activities' page, only activities  
  that have not been  reviewed and  
  incomplete can be edited.
* Update model spec.

[Finishes: #88824148]