### PR TITLE
Add status to past activities.

### DIFF
--- a/app/helpers/think_feel_do_engine/coach/group_dashboard_helper.rb
+++ b/app/helpers/think_feel_do_engine/coach/group_dashboard_helper.rb
@@ -100,6 +100,20 @@ module ThinkFeelDoEngine
         end
       end
 
+      def activity_status(activity)
+        if activity.monitored?
+          "monitored"
+        elsif activity.not_reviewed?
+          "not reviewed"
+        elsif activity.planned?
+          "planned"
+        elsif activity.reviewed_and_complete?
+          "reviewed and complete"
+        elsif activity.reviewed_and_incomplete?
+          "reviewed and incomplete"
+        end
+      end
+
       private
 
       def week_of_task(task)

--- a/app/views/think_feel_do_engine/coach/group_dashboard/_activities_past.html.erb
+++ b/app/views/think_feel_do_engine/coach/group_dashboard/_activities_past.html.erb
@@ -37,7 +37,7 @@
                 </td>
                 <td><%= membership.participant.display_name %></td>
                 <td><%= ActivityType.find(activity.activity_type_id).title %> </td>
-                <td></td>
+                <td><%= activity_status(activity) %></td>
                 <td><%= activity.end_time ? activity.end_time.to_formatted_s(:short) : content_tag(:span, "Unscheduled", class: "label label-warning") %></td>
                 <td><%= activity.actual_accomplishment_intensity ? activity.actual_accomplishment_intensity : content_tag(:span, "Not Rated", class: "label label-warning") %></td>
                 <td><%= activity.actual_pleasure_intensity ? activity.actual_pleasure_intensity : content_tag(:span, "Not Rated", class: "label label-warning") %></td>

--- a/spec/helpers/think_feel_do_engine/group_dashboard_helper_spec.rb
+++ b/spec/helpers/think_feel_do_engine/group_dashboard_helper_spec.rb
@@ -36,6 +36,48 @@ module ThinkFeelDoEngine
         end
       end
 
+      describe "#activity_status" do
+        let(:activity) { double("activity") }
+
+        it "should return monitored status when activity is monitored" do
+          expect(activity).to receive(:monitored?) { true }
+
+          expect(helper.activity_status(activity)).to eq("monitored")
+        end
+
+        it "should return (not reviewed) status when activity not_reviewed" do
+          expect(activity).to receive(:monitored?) { false }
+          expect(activity).to receive(:not_reviewed?) { true }
+
+          expect(helper.activity_status(activity)).to eq("not reviewed")
+        end
+
+        it "should return planned status when activity is planned?" do
+          expect(activity).to receive(:monitored?) { false }
+          expect(activity).to receive(:not_reviewed?) { false }
+          expect(activity).to receive(:planned?) { true }
+
+          expect(helper.activity_status(activity)).to eq("planned")
+        end
+        it "should return (reviewed and complete) status when activity is reviewed and complete" do
+          expect(activity).to receive(:monitored?) { false }
+          expect(activity).to receive(:not_reviewed?) { false }
+          expect(activity).to receive(:planned?) { false }
+          expect(activity).to receive(:reviewed_and_complete?) { true }
+
+          expect(helper.activity_status(activity)).to eq("reviewed and complete")
+        end
+        it "should return (reviewed and incomplete) status when activity is reviewed and incomplete" do
+          expect(activity).to receive(:monitored?) { false }
+          expect(activity).to receive(:not_reviewed?) { false }
+          expect(activity).to receive(:planned?) { false }
+          expect(activity).to receive(:reviewed_and_complete?) { false }
+          expect(activity).to receive(:reviewed_and_incomplete?) { true }
+
+          expect(helper.activity_status(activity)).to eq("reviewed and incomplete")
+        end
+      end
+
       describe "comment_item_description" do
         it "should return details for unknown shared items" do
           comment = double("comment", item_type: "Mood", item_id: 1)


### PR DESCRIPTION
* Added contents to the status column in group dash.
* Applies only to past activities.
* Added spec to test the new helper method.

[Finished #89312214]