### PR TITLE
Add patient summary data to coach dash

### DIFF
--- a/app/models/activity.rb
+++ b/app/models/activity.rb
@@ -49,9 +49,12 @@ class Activity < ActiveRecord::Base
     where(
       arel_table[:start_time]
       .gteq(Time.current.advance(days: -7).beginning_of_day)
-    ).in_the_past
+    )
   }
 
+  # To Do: fix naming and/or what is going on here
+  # change to start_time and is_scheduled
+  # and updated tests
   scope :unscheduled_or_in_the_future, lambda {
     where(
       arel_table[:start_time].eq(nil)
@@ -69,6 +72,31 @@ class Activity < ActiveRecord::Base
         actual_pleasure_intensity: nil)
   }
 
+  scope :reviewed_and_incomplete, lambda {
+    where(is_reviewed: true)
+      .where(
+        actual_accomplishment_intensity: nil,
+        actual_pleasure_intensity: nil)
+      .where
+      .not(
+        predicted_accomplishment_intensity: nil,
+        predicted_pleasure_intensity: nil)
+  }
+
+  scope :monitored, lambda {
+    where(is_reviewed: false)
+      .where(
+        actual_accomplishment_intensity: nil,
+        actual_pleasure_intensity: nil)
+      .where
+      .not(
+        predicted_accomplishment_intensity: nil,
+        predicted_pleasure_intensity: nil)
+  }
+
+  # To Do: fix naming and/or what is going on here
+  # change to start_time
+  # and updated tests
   scope :in_the_future, lambda {
     where(
       arel_table[:end_time].gt(Time.current)

--- a/app/models/membership.rb
+++ b/app/models/membership.rb
@@ -113,12 +113,35 @@ class Membership < ActiveRecord::Base
       .count
   end
 
-  def comments
-    SocialNetworking::Comment.where(participant: participant)
+  def logins_today
+    participant_login_events = Arel::Table.new(:participant_login_events)
+    participant
+      .participant_login_events
+      .where(participant_login_events[:created_at]
+                 .gteq(Date.current.beginning_of_day))
+      .where(participant_login_events[:created_at]
+                 .lt(Date.current.end_of_day))
   end
 
-  def goals
-    SocialNetworking::Goal.where(participant: participant)
+  def lessons_read
+    task_statuses.completed.select(&:is_lesson?)
+  end
+
+  def lessons_read_for_day(time)
+    task_statuses
+      .completed
+      .where("completed_at <= ? AND completed_at >= ?",
+             time.end_of_day,
+             time.beginning_of_day)
+      .select(&:is_lesson?)
+  end
+
+  def lessons_read_for_week
+    task_statuses
+      .completed
+      .where("completed_at >= ?", Time.current.advance(days: -7)
+                                      .beginning_of_day)
+      .select(&:is_lesson?)
   end
 
   private

--- a/app/models/mood.rb
+++ b/app/models/mood.rb
@@ -14,4 +14,18 @@ class Mood < ActiveRecord::Base
   def rating_value
     Values::Mood.from_rating(rating).to_s
   end
+
+  scope :last_seven_days, lambda {
+    where(
+      arel_table[:created_at]
+        .gteq(Time.current.advance(days: -7).beginning_of_day))
+  }
+
+  scope :for_day, lambda { |time|
+    where(
+      arel_table[:created_at]
+        .gteq(time.beginning_of_day)
+        .and(arel_table[:created_at].lteq(time.end_of_day))
+    )
+  }
 end

--- a/app/models/thought.rb
+++ b/app/models/thought.rb
@@ -24,8 +24,22 @@ class Thought < ActiveRecord::Base
   scope :unreflected, lambda {
     where(effect: "harmful")
       .where(arel_table[:challenging_thought].eq(nil)
-             .or(arel_table[:challenging_thought].eq(""))
-             .or(arel_table[:act_as_if].eq(nil))
-             .or(arel_table[:act_as_if].eq("")))
+        .or(arel_table[:challenging_thought].eq(""))
+        .or(arel_table[:act_as_if].eq(nil))
+        .or(arel_table[:act_as_if].eq("")))
+  }
+
+  scope :last_seven_days, lambda {
+    where(
+      arel_table[:created_at]
+        .gteq(Time.current.advance(days: -7).beginning_of_day))
+  }
+
+  scope :for_day, lambda { |time|
+    where(
+      arel_table[:created_at]
+        .gteq(time.beginning_of_day)
+        .and(arel_table[:created_at].lteq(time.end_of_day))
+    )
   }
 end

--- a/app/views/think_feel_do_engine/coach/patient_dashboards/show.html.erb
+++ b/app/views/think_feel_do_engine/coach/patient_dashboards/show.html.erb
@@ -5,38 +5,7 @@
     <%= link_to "Patients", coach_group_patient_dashboards_path(@group), class: "btn btn-default" %>
   </div>
 
-  <div class="panel panel-default">
-    <div class="panel-heading">
-      <h3 class="panel-title">General Patient Info</h3>
-    </div>
-
-    <div class="panel-body">
-      <% if view_membership(@participant, @group) %>
-        <p>
-          <strong><i class="fa fa-calendar"></i> Started on:</strong>
-          <%= view_membership(@participant, @group).start_date.to_s :brief_date %>
-        </p>
-        <p>
-          <strong><i class="fa fa-calendar"></i> <%= study_length_in_weeks %> weeks from the start date is:</strong>
-          <%= (view_membership(@participant, @group).start_date + study_length_in_weeks.weeks).to_s :brief_date %>
-        </p>
-      <% end %>
-
-      <p>
-        <strong>Status:</strong>
-        <% if view_membership(@participant, @group).end_date > Date.current %>
-          <span class="label label-success full-size">Active</span> &middot; Currently in week <%= (view_membership(@participant, @group).day_in_study / 7.0).ceil %>
-        <% else %>
-          <span class="label label-warning full-size">Inactive</span> &middot; Study has been Completed
-        <% end %>
-      </p>
-
-      <p>
-        <strong>Last Logged In:</strong>
-        <%= @participant.current_sign_in_at ? @participant.current_sign_in_at.to_s(:brief_date_time) : "Never Logged In" %>
-      </p>
-    </div>
-  </div>
+  <%= render "think_feel_do_engine/coach/patient_dashboards/summary/patient_summary_table", patient: @participant %>
 
   <h3>Table of Contents</h3>
 

--- a/app/views/think_feel_do_engine/coach/patient_dashboards/summary/_patient_info.html.erb
+++ b/app/views/think_feel_do_engine/coach/patient_dashboards/summary/_patient_info.html.erb
@@ -1,0 +1,42 @@
+<div class="col-lg-6">
+  <div class="panel panel-default">
+    <div class="panel-heading">
+      <h3 class="panel-title">
+        General Patient Info
+      </h3>
+    </div>
+
+    <div class="panel-body">
+      <% if view_membership(@participant, @group) %>
+        <p>
+          <strong>Started on:</strong>
+          <%= view_membership(@participant, @group).start_date.to_s :brief_date %>
+        </p>
+        <p>
+          <strong><%= study_length_in_weeks %> weeks from the start date is:</strong>
+          <%= (view_membership(@participant, @group).start_date + study_length_in_weeks.weeks).to_s :brief_date %>
+        </p>
+      <% end %>
+
+      <p>
+        <strong>Status:</strong>
+        <% if view_membership(@participant, @group).end_date > Date.current %>
+          <span class="label label-success full-size">Active</span>
+        <% else %>
+          <span class="label label-warning full-size">Inactive</span>
+        <% end %>
+        <% if view_membership(@participant, @group).end_date > Date.current %>
+          Currently in week <%= (view_membership(@participant, @group).day_in_study / 7.0).ceil %>
+        <% else %>
+          Study has been Completed
+        <% end %>
+      </p>
+
+      <p>
+        <strong>Lessons read this week:</strong>
+        <%= @participant.active_membership ? @participant.active_membership.lessons_read_for_week.count : 0 %>
+      </p>
+
+    </div>
+  </div>
+</div>

--- a/app/views/think_feel_do_engine/coach/patient_dashboards/summary/_patient_login_stats.html.erb
+++ b/app/views/think_feel_do_engine/coach/patient_dashboards/summary/_patient_login_stats.html.erb
@@ -1,0 +1,36 @@
+<div class="col-lg-6">
+  <div class="panel panel-default">
+    <div class="panel-heading">
+      <h3 class="panel-title">
+        Login Info
+      </h3>
+    </div>
+
+    <div class="panel-body">
+      <p>
+        <strong>Last Logged In:</strong>
+        <%= @participant.current_sign_in_at ? @participant.current_sign_in_at.to_s(:brief_date_time) : "Never Logged In" %>
+      </p>
+
+      <p>
+        <strong>Logins Today:</strong>
+        <%= @participant.active_membership ? @participant.active_membership.logins_today.count : 0 %>
+      </p>
+
+      <p>
+        <strong>Logins in the last seven days:</strong>
+        <%= @participant.active_membership ?
+          @participant
+            .active_membership
+            .logins_by_week(@participant
+              .active_membership
+              .week_in_study(Date.today)) : 0 %>
+      </p>
+
+      <p>
+        <strong>Total Logins:</strong>
+        <%= @participant.participant_login_events.count %>
+      </p>
+    </div>
+  </div>
+</div>

--- a/app/views/think_feel_do_engine/coach/patient_dashboards/summary/_patient_summary_table.html.erb
+++ b/app/views/think_feel_do_engine/coach/patient_dashboards/summary/_patient_summary_table.html.erb
@@ -1,0 +1,2 @@
+<%= render "think_feel_do_engine/coach/patient_dashboards/summary/patient_info" %>
+<%= render "think_feel_do_engine/coach/patient_dashboards/summary/patient_login_stats" %>

--- a/spec/models/activity_spec.rb
+++ b/spec/models/activity_spec.rb
@@ -51,6 +51,32 @@ RSpec.describe Activity do
       end
     end
 
+    describe ".reviewed_and_incomplete" do
+      it "returns all activities that have been reviewed and have predicted intensities, but not actual intensities" do
+        expect do
+          sleeping(
+            predicted_accomplishment_intensity: 5,
+            predicted_pleasure_intensity: 5,
+            actual_accomplishment_intensity: nil,
+            actual_pleasure_intensity: nil,
+            is_reviewed: true)
+        end.to change { Activity.reviewed_and_incomplete.count }.by(1)
+      end
+    end
+
+    describe ".monitored" do
+      it "returns activities that have not been reviwed and have predicted intensities, but not actual intensities " do
+        expect do
+          sleeping(
+            predicted_accomplishment_intensity: 5,
+            predicted_pleasure_intensity: 5,
+            actual_accomplishment_intensity: nil,
+            actual_pleasure_intensity: nil,
+            is_reviewed: false)
+        end.to change { Activity.monitored.count }.by(1)
+      end
+    end
+
     describe ".accomplished" do
       it "returns actitivies that have an actual accomplishment >= to a cutoff" do
         expect do


### PR DESCRIPTION
* Add separate tables for social daily/weekly/total
  stats and site tool use
* Add revised patient info summary table
* Add new login info summary table
* Supports development of the patient
  summary features on the coach dashboard
Add activity summary data to patient dashboard

* Add scopes for reviewed and complete activities; monitored
* Add specs for newly added scopes
* Add counts based on scoped data to views
  * planned
  * monitored
  * reviewed and complete
  * reviewed and incomplete
  -- for today, this week, total

Add login stats, goal stats to patient dash

* Add methods to membership to access goal
  stats by day, week, total
* Add login stats for week, total
* Lessons read by day, week, total
* Moods recorded by day, week, total
* Thoughts entered by day, week total

* A bit of view refactoring (more modular) to support compatibility with social views.

Supporting changes for this commit are in https://github.com/cbitstech/social_networking/tree/gs-add-social-scopes (model scopes for social data). Views will be pushed to TFDSO soon.

[#89517128]