### PR TITLE
Reporter sanitizes the file path more strictly

### DIFF
--- a/app/models/think_feel_do_engine/reports/reporter.rb
+++ b/app/models/think_feel_do_engine/reports/reporter.rb
@@ -14,7 +14,7 @@ module ThinkFeelDoEngine
 
       def self.file_path(name)
         Rails.application.config.reports_root_path
-          .join("reports/#{name.to_s.gsub('_', '').downcase}.csv")
+          .join("reports/#{name.to_s.scan(/[a-z]+/).join.downcase}.csv")
       end
 
       def initialize(collector)

--- a/spec/models/think_feel_do_engine/reports/reporter_spec.rb
+++ b/spec/models/think_feel_do_engine/reports/reporter_spec.rb
@@ -4,10 +4,18 @@ module ThinkFeelDoEngine
   module Reports
     RSpec.describe Reporter do
       let(:collector) do
-        double(name: "collector",
-               columns: %w( a b ),
-               all: [{ a: 1, b: 2 }, { a: "x", b: "y" }]
-              )
+        double(
+          name: "collector",
+          columns: %w( a b ),
+          all: [{ a: 1, b: 2 }, { a: "x", b: "y" }]
+        )
+      end
+      let(:messy_collector) do
+        double(
+          name: "collector23%",
+          columns: %w( a b ),
+          all: [{ a: 1, b: 2 }, { a: "x", b: "y" }]
+        )
       end
 
       describe "#format_csv" do
@@ -19,6 +27,10 @@ module ThinkFeelDoEngine
       describe ".file_path" do
         it "generates the proper file path" do
           expect(Reporter.file_path(collector.name)).to eq(Rails.root.join("reports/collector.csv"))
+        end
+
+        it "sanitizes the file path to only include letters" do
+          expect(Reporter.file_path(messy_collector.name)).to eq(Rails.root.join("reports/collector.csv"))
         end
       end
     end


### PR DESCRIPTION
* Only allow [a-z]+ charecters
* Discard the rest
* Add a spec to test cleanliness

[#90118312]