### PR TITLE
Fix double popup when participant shares activity

### DIFF
--- a/app/views/think_feel_do_engine/activities/past_activity_form.html.erb
+++ b/app/views/think_feel_do_engine/activities/past_activity_form.html.erb
@@ -12,8 +12,7 @@
         html: {
           role: "form",
           class: "activity_form",
-          id: nil,
-          onsubmit: "validatePublic(event,'activity_shared_item_true')"
+          id: nil
         }
       ) do |f| %>
       <%= f.hidden_field :start_time, value: start_time %>


### PR DESCRIPTION
* Removed extra call from form to
  validate_social_sharing.js
* validate_social_sharing.js is already
  listening for changes on this page
* Now just one confirmation popup shows

[#90303490]