### PR TITLE
Add descriptions for thought sharing

### DIFF
--- a/app/assets/javascripts/think_feel_do_engine/validate_social_sharing.js
+++ b/app/assets/javascripts/think_feel_do_engine/validate_social_sharing.js
@@ -27,7 +27,7 @@ var validateMutliFormPage = function(event, shared_item_name, activity_id) {
     if (shared_item_buttons != null && 0 < shared_item_buttons.length) {
       for (var current_button_index = 0; current_button_index < shared_item_buttons.length && !validatedSocialSubmit; current_button_index++) {
         if (shared_item_buttons[current_button_index].checked) {
-          if (confirm('Are you sure that you would like to make this activity public?')) {
+          if (confirm('Are you sure that you would like to make this public?')) {
             validatedSocialSubmit = true;
             return true;
           } else {

--- a/app/models/thought.rb
+++ b/app/models/thought.rb
@@ -43,6 +43,18 @@ class Thought < ActiveRecord::Base
     )
   }
 
+  def status_label
+    if !pattern_id && !challenging_thought
+      "Identified"
+    elsif pattern_id && !challenging_thought
+      "Assigned a pattern to"
+    elsif challenging_thought
+      "Reshaped"
+    else
+      "Shared"
+    end
+  end
+
   def shared_description
     "Thought: #{ content }"
   end

--- a/app/views/think_feel_do_engine/thoughts/_form.html.erb
+++ b/app/views/think_feel_do_engine/thoughts/_form.html.erb
@@ -4,7 +4,7 @@
   <%= render 'think_feel_do_engine/thoughts/thought_effects', f: f, thought: thought %>
 
   <% if current_participant.active_group.arm.social? %>
-    <span class="new-shareable-form-after-form-groups" data-item-type="thought" data-action-type="planned"></span>
+    <span class="new-shareable-form-after-form-groups" data-item-type="thought" data-action-type=""></span>
   <% end %>
 
   <%= content_tag(:button, t(:next), type: "submit", class: "btn btn-primary pull-right") %>

--- a/app/views/think_feel_do_engine/thoughts/edit_bulk.html.erb
+++ b/app/views/think_feel_do_engine/thoughts/edit_bulk.html.erb
@@ -11,7 +11,8 @@
         remote: true,
         html: {
           class: "multi-page#{ i == 0 ? "" : " not-displayed" }",
-          role: "form"
+          role: "form",
+          onsubmit: "validatePublic(event,'thought_shared_item_true')"
         }
       ) do |f|
     %>
@@ -27,6 +28,10 @@
       </div>
 
       <%= render 'think_feel_do_engine/thoughts/thought_patterns', f: f %>
+
+      <% if current_participant.active_group.arm.social? %>
+        <span class="new-shareable-form-after-form-groups" data-item-type="thought" data-action-type=""></span>
+      <% end %>
 
       <%= content_tag(:button, t(:next), type: "submit", class: "btn btn-primary pull-right") %>
     <% end %>

--- a/app/views/think_feel_do_engine/thoughts/new_bulk.html.erb
+++ b/app/views/think_feel_do_engine/thoughts/new_bulk.html.erb
@@ -27,7 +27,7 @@
     <%= render 'think_feel_do_engine/thoughts/thought_effects', f: f, thought: thought %>
 
     <% if current_participant.active_group.arm.social? %>
-      <span class="new-shareable-form-after-form-groups" data-item-type="thought" data-action-type="planned"></span>
+      <span class="new-shareable-form-after-form-groups" data-item-type="thought" data-action-type=""></span>
     <% end %>
 
     <%= content_tag(:button, t(:next), type: "submit", class: "btn btn-primary pull-right") %>

--- a/app/views/think_feel_do_engine/thoughts/new_complete.html.erb
+++ b/app/views/think_feel_do_engine/thoughts/new_complete.html.erb
@@ -18,7 +18,7 @@
   </div>
 
   <% if current_participant.active_group.arm.social? %>
-    <span class="new-shareable-form-after-form-groups" data-item-type="thought" data-action-type="planned"></span>
+    <span class="new-shareable-form-after-form-groups" data-item-type="thought" data-action-type=""></span>
   <% end %>
 
   <div class="btn-group pull-right">

--- a/app/views/think_feel_do_engine/thoughts/new_harmful.html.erb
+++ b/app/views/think_feel_do_engine/thoughts/new_harmful.html.erb
@@ -6,7 +6,7 @@
   <%= f.hidden_field(:effect) %>
 
   <% if current_participant.active_group.arm.social? %>
-    <span class="new-shareable-form-after-form-groups" data-item-type="thought" data-action-type="planned"></span>
+    <span class="new-shareable-form-after-form-groups" data-item-type="thought" data-action-type=""></span>
   <% end %>
 
   <%= content_tag(:button, t(:next), type: "submit", class: "btn btn-primary pull-right") %>

--- a/app/views/think_feel_do_engine/thoughts/unhelpful_thoughts_form.html.erb
+++ b/app/views/think_feel_do_engine/thoughts/unhelpful_thoughts_form.html.erb
@@ -61,7 +61,11 @@
     </div>
 
     <!-- "slide 4" -->
-    <%= form_for thought, url: update_path, html: { class: "multi-form not-displayed" }, remote: true do |f| %>
+    <%= form_for thought,
+                 url: update_path,
+                 html: { class: "multi-form not-displayed" },
+                 onsubmit: "validatePublic(event,'thought_shared_item_true')",
+                 remote: true do |f| %>
       <div class="panel panel-default">
         <div class="panel-heading">
           <h3 class="panel-title adjusted-panel-title">
@@ -84,8 +88,14 @@
       <%= f.label :act_as_if, "What could you do to ACT AS IF you believe this?" %>
       <%= f.text_area :act_as_if, class: "form-control", required: true, rows: 3 %><br>
       <%= f.hidden_field :id %>
+
+      <% if current_participant.active_group.arm.social? %>
+        <span class="new-shareable-form-after-form-groups" data-item-type="thought" data-action-type=""></span>
+      <% end %>
+
         <%= content_tag(:button, t(:next), type: "submit", class: "btn btn-primary pull-right") %>
     <% end %>
+
   <% end %>
 
 <% else %>

--- a/spec/models/thought_spec.rb
+++ b/spec/models/thought_spec.rb
@@ -13,4 +13,28 @@ RSpec.describe Activity do
       expect(thought.shared_description).to eq("Thought: content")
     end
   end
+
+  describe "#status_label" do
+    let(:participant) { participants(:participant1) }
+    it "returns how the participant has amended the thought" do
+      thought = Thought
+                .new(participant:
+                       participant,
+                     effect: "harmful",
+                     content: "content")
+      expect(thought.status_label).to eq("Identified")
+
+      thought = Thought
+                .new(participant: participant,
+                     effect: "harmful",
+                     content: "content", pattern_id: 2323)
+      expect(thought.status_label).to eq("Assigned a pattern to")
+
+      thought = Thought
+                .new(participant: participant,
+                     effect: "harmful",
+                     challenging_thought: "content")
+      expect(thought.status_label).to eq("Reshaped")
+    end
+  end
 end


### PR DESCRIPTION
* Add states to thoughts based on tool progress
* Add social sharing forms to views
* Allow thought pattern assignments to be shared
* Allow thought reshapings to be shared
* Update text of confirmation popup
  for sharing items to match either
  sharing an activity or thought
* Spec for thought status

[#90925872]