### PR TITLE
Track activity tool use more accurately

### DIFF
--- a/app/models/activity.rb
+++ b/app/models/activity.rb
@@ -51,8 +51,16 @@ class Activity < ActiveRecord::Base
 
   scope :last_seven_days, lambda {
     where(
-      arel_table[:start_time]
+      arel_table[:updated_at]
       .gteq(Time.current.advance(days: -7).beginning_of_day)
+    )
+  }
+
+  scope :updated_for_day, lambda { |time|
+    where(
+      arel_table[:updated_at]
+        .gteq(time.beginning_of_day)
+        .and(arel_table[:updated_at].lteq(time.end_of_day))
     )
   }
 
@@ -89,11 +97,11 @@ class Activity < ActiveRecord::Base
 
   scope :monitored, lambda {
     where(is_reviewed: false)
-      .where(
-        actual_accomplishment_intensity: nil,
-        actual_pleasure_intensity: nil)
       .where
       .not(
+        actual_accomplishment_intensity: nil,
+        actual_pleasure_intensity: nil)
+      .where(
         predicted_accomplishment_intensity: nil,
         predicted_pleasure_intensity: nil)
   }

--- a/app/views/think_feel_do_engine/coach/patient_dashboards/tables/_summary_totals.html.erb
+++ b/app/views/think_feel_do_engine/coach/patient_dashboards/tables/_summary_totals.html.erb
@@ -21,27 +21,27 @@
     <td><%= @participant.thoughts.last_seven_days.count %></td>
     <td><%= @participant.thoughts.count %></td>
   </tr>
-  <tr id="<%= @participant.id %>-activties-planned-totals">
-    <td><a href="#activity_futureCollapse">Activities Planned</a></td>
-    <td><%= @participant.activities.planned.for_day(Date.today).count %></td>
-    <td><%= @participant.activities.planned.last_seven_days.count %></td>
-    <td><%= @participant.activities.planned.count %></td>
-  </tr>
   <tr id="<%= @participant.id %>-activities-monitored-totals">
     <td><a href="#activity_pastCollapse">Activities Monitored</a></td>
-    <td><%= @participant.activities.monitored.for_day(Date.today).count %></td>
+    <td><%= @participant.activities.monitored.updated_for_day(Date.today).count %></td>
     <td><%= @participant.activities.monitored.last_seven_days.count %></td>
     <td><%= @participant.activities.monitored.count %></td>
   </tr>
+  <tr id="<%= @participant.id %>-activties-planned-totals">
+    <td><a href="#activity_futureCollapse">Activities Planned</a></td>
+    <td><%= @participant.activities.planned.updated_for_day(Date.today).count %></td>
+    <td><%= @participant.activities.planned.last_seven_days.count %></td>
+    <td><%= @participant.activities.planned.count %></td>
+  </tr>
   <tr id="<%= @participant.id %>-activities-reviewed-complete-totals">
     <td><a href="#activity_pastCollapse">Activities Reviewed and Completed</a></td>
-    <td><%= @participant.activities.reviewed_and_complete.for_day(Date.today).count %></td>
+    <td><%= @participant.activities.reviewed_and_complete.updated_for_day(Date.today).count %></td>
     <td><%= @participant.activities.reviewed_and_complete.last_seven_days.count %></td>
     <td><%= @participant.activities.reviewed_and_complete.count %></td>
   </tr>
   <tr id="<%= @participant.id %>-activities-reviewed-incomplete-totals">
     <td><a href="#activity_pastCollapse">Activities Reviewed and Incomplete</a></td>
-    <td><%= @participant.activities.reviewed_and_incomplete.for_day(Date.today).count %></td>
+    <td><%= @participant.activities.reviewed_and_incomplete.updated_for_day(Date.today).count %></td>
     <td><%= @participant.activities.reviewed_and_incomplete.last_seven_days.count %></td>
     <td><%= @participant.activities.reviewed_and_incomplete.count %></td>
   </tr>

--- a/spec/models/activity_spec.rb
+++ b/spec/models/activity_spec.rb
@@ -64,13 +64,13 @@ RSpec.describe Activity do
     end
 
     describe ".monitored" do
-      it "returns activities that have not been reviwed and have predicted intensities, but not actual intensities " do
+      it "returns activities that have not been reviwed and have actual intensities, but not predicted intensities " do
         expect do
           sleeping(
-            predicted_accomplishment_intensity: 5,
-            predicted_pleasure_intensity: 5,
-            actual_accomplishment_intensity: nil,
-            actual_pleasure_intensity: nil,
+            predicted_accomplishment_intensity: nil,
+            predicted_pleasure_intensity: nil,
+            actual_accomplishment_intensity: 5,
+            actual_pleasure_intensity: 5,
             is_reviewed: false)
         end.to change { Activity.monitored.count }.by(1)
       end
@@ -118,9 +118,18 @@ RSpec.describe Activity do
     describe ".last_seven_days" do
       it "returns actitivies have taken place during the last 7 days" do
         expect do
-          sleeping start_time: Time.current.advance(days: -7)
-          sleeping start_time: Time.current.advance(days: -8)
+          sleeping updated_at: Time.current.advance(days: -7)
+          sleeping updated_at: Time.current.advance(days: -8)
         end.to change { Activity.last_seven_days.count }.by(1)
+      end
+    end
+
+    describe ".updated_for_day" do
+      it "returns only the activities updated on that day" do
+        expect do
+          sleeping updated_at: Time.local(2016, 1, 15, 22)
+          sleeping updated_at: Time.local(2016, 1, 16, 22)
+        end.to change { Activity.updated_for_day(Time.local(2016, 1, 15)).count }.by 1
       end
     end
 


### PR DESCRIPTION
* Update "last seven days" scope to
  track when the activity was updated, not
  planned for
* Add new "updated for day" scope to
  track activities updated for a given day
* Fix business logic for "monitored" scope
  to reflect actual biz logic
* Update patient dashboard summary to
  use new scopes where appropraite
* Update specs to reflect changes
* Move "activities monitored" rows above
  "activities planned."

[#91095350]
[#91113204]
[#91113196]
[#91113172]
[#91113148]
[#91052544]
[#91052696]