### PR TITLE
Scope Site Messages

### DIFF
--- a/app/controllers/think_feel_do_engine/coach/site_messages_controller.rb
+++ b/app/controllers/think_feel_do_engine/coach/site_messages_controller.rb
@@ -6,8 +6,8 @@ module ThinkFeelDoEngine
       load_and_authorize_resource except: [:index]
 
       def index
-        authorize! :show, SiteMessage
-        participant_ids = @group.participant_ids
+        authorize! :index, SiteMessage
+        participant_ids = current_user.participants_for_group(@group).ids
         @site_messages =
           SiteMessage
           .where(participant_id: participant_ids)
@@ -17,7 +17,7 @@ module ThinkFeelDoEngine
       end
 
       def new
-        @participants = @group.participants
+        @participants = current_user.participants_for_group(@group)
       end
 
       def create

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -36,6 +36,10 @@ class User < ActiveRecord::Base
     sent_messages.build(attributes)
   end
 
+  def participants_for_group(group)
+    participants.where(id: group.participant_ids)
+  end
+
   def password_is__not_blank?
     !password.blank?
   end

--- a/spec/controllers/think_feel_do_engine/coach/site_messages_controller_spec.rb
+++ b/spec/controllers/think_feel_do_engine/coach/site_messages_controller_spec.rb
@@ -1,0 +1,100 @@
+require "rails_helper"
+
+module ThinkFeelDoEngine
+  module Coach
+    urls = ThinkFeelDoEngine::Engine.routes.url_helpers
+
+    describe SiteMessagesController, type: :controller do
+      let(:user) { double("user", admin?: true) }
+      let(:group) { double("group") }
+
+      describe "GET index" do
+        context "for unauthenticated requests" do
+          before { get :index, use_route: :think_feel_do_engine }
+          it_behaves_like "a rejected user action"
+        end
+
+        context "for authenticated requests" do
+          before do
+            sign_in_user user
+            allow(Group).to receive(:find).and_return(group)
+            allow(user).to receive_message_chain(:participants_for_group, ids: [])
+          end
+
+          it "responds with the group's participants but scoped to the current user" do
+            expect(user).to receive(:participants_for_group).with(group)
+
+            get :index, use_route: :think_feel_do_engine
+
+            expect(response).to render_template :index
+          end
+        end
+      end
+
+      describe "GET new" do
+        context "for unauthenticated requests" do
+          before { get :new, use_route: :think_feel_do_engine }
+          it_behaves_like "a rejected user action"
+        end
+
+        context "for authenticated requests" do
+          before do
+            sign_in_user user
+            allow(Group).to receive(:find).and_return(group)
+          end
+
+          it "responds with the group's participants but scoped to the current user" do
+            expect(user).to receive(:participants_for_group).with(group)
+
+            get :new, use_route: :think_feel_do_engine
+
+            expect(response).to render_template :new
+          end
+        end
+      end
+
+      describe "POST create" do
+        context "for unauthenticated requests" do
+          before { post :create, use_route: :think_feel_do_engine }
+          it_behaves_like "a rejected user action"
+        end
+
+        context "for authenticated requests" do
+          before do
+            sign_in_user user
+            allow(Group).to receive(:find).and_return(group)
+          end
+
+          describe "with errors" do
+            let(:site_message) { double("site_message", save: false) }
+
+            before do
+              allow(SiteMessage).to receive(:new) { site_message }
+            end
+
+            it "should respond with the new page if there is an error" do
+              post :create, site_message: { participant_id: 1 }, use_route: :think_feel_do_engine
+
+              expect(response).to render_template :new
+            end
+          end
+
+          describe "on success" do
+            let(:site_message) { double("site_message", save: true) }
+
+            before do
+              allow(SiteMessage).to receive(:new) { site_message }
+              allow(SiteMessageMailer).to receive_message_chain(:general, deliver: true)
+            end
+
+            it "should respond with the show page of the message" do
+              post :create, site_message: { participant_id: 1 }, use_route: :think_feel_do_engine
+
+              expect(response).to redirect_to urls.coach_group_site_message_path(group, site_message)
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,0 +1,13 @@
+require "rails_helper"
+
+describe User do
+  fixtures :all
+
+  let(:group) { groups(:group1) }
+  let(:clinician) { users(:clinician1) }
+
+  it ".participants_for_group returns the assigned participants within a group" do
+    expect(clinician.participants_for_group(group)).to include participants(:participant1)
+    expect(clinician.participants_for_group(group)).not_to include participants(:participant2)
+  end
+end


### PR DESCRIPTION
Scope Site Messages

* Add `User` model method to scope participants to a user based on group.
* Add scoping to site_messaging controller actions index and new.
* Add controller and model specs.

[Finished: #92731296] [Finished: #92731434]