### PR TITLE
Add format for time, update lesson view table

### DIFF
--- a/app/views/think_feel_do_engine/coach/patient_dashboards/tables/_lessons_table.html.erb
+++ b/app/views/think_feel_do_engine/coach/patient_dashboards/tables/_lessons_table.html.erb
@@ -20,6 +20,7 @@
             <th>Lesson Selected At</th>
             <th>Last Page Number Opened</th>
             <th>Last Page Opened At</th>
+            <th>Duration</th>
           </tr>
           </thead>
           <tbody>

--- a/app/views/think_feel_do_engine/learn/_completion_data.html.erb
+++ b/app/views/think_feel_do_engine/learn/_completion_data.html.erb
@@ -8,8 +8,9 @@
     </td>
     <td><%= ContentModules::LessonModule.find(lesson_event[:lesson_id]).title %></td>
     <td><%= lesson_event[:page_headers][2] %></td>
-    <td><%= l(DateTime.iso8601(lesson_event[:lesson_selected_at]), format: :standard) %></td>
+    <td><%= l(DateTime.iso8601(lesson_event[:lesson_selected_at]), format: :with_seconds) %></td>
     <td><%= lesson_event[:last_page_number_opened] %></td>
-    <td><%= l(DateTime.iso8601(lesson_event[:last_page_opened_at]), format: :standard) %></td>
+    <td><%= l(DateTime.iso8601(lesson_event[:last_page_opened_at]), format: :with_seconds) %></td>
+    <td><%= distance_of_time_in_words(DateTime.iso8601(lesson_event[:last_page_opened_at]) - DateTime.iso8601(lesson_event[:lesson_selected_at])) %></td>
   </tr>
 <% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -7,6 +7,7 @@ en:
     formats:
       standard: "%b %d %Y %H:%M"
       login: "%A, %b %d %Y %H:%M"
+      with_seconds: "%b %d %Y %H:%M:%S"
 
   date:
     formats:
@@ -17,3 +18,4 @@ en:
     formats:
       standard: "%b %d %Y %H:%M"
       login: "%A, %b %d %Y %H:%M"
+      with_seconds: "%b %d %Y %H:%M:%S"


### PR DESCRIPTION
* Add a format for time and datetime that has seconds
* Update time formats in lesson view table on patient dashboard to show seconds
* Add column on lesson view table on patient dashboard to show duration

[Finish #96783814]