### PR TITLE
Update planning activity examples in specs

### DIFF
--- a/spec/features/participant/activities/content_providers/fun_activity_checklist_spec.rb
+++ b/spec/features/participant/activities/content_providers/fun_activity_checklist_spec.rb
@@ -15,8 +15,8 @@ feature "Activities", type: :feature do
         find("input[value='Loving'][type='radio']").click
         fill_in "future_date_picker_0", with: Date.today + 1.day
         choose_rating "pleasure_0", 10
-        select 9, from: "How much pleasure did you expect to get from doing this?"
-        select 9, from: "How much accomplishment do you expect to get from doing this?"
+        select 9, from: "planned_activity[predicted_pleasure_intensity]"
+        select 9, from: "planned_activity[predicted_accomplishment_intensity]"
         click_on "Next"
 
         expect(page).to have_text("Now, plan something that gives you a sense of accomplishment.")

--- a/spec/features/participant/activities/content_providers/important_activity_checklist_spec.rb
+++ b/spec/features/participant/activities/content_providers/important_activity_checklist_spec.rb
@@ -24,8 +24,8 @@ feature "Activities", type: :feature do
                 "/providers/" \
                 "#{ bit_core_content_providers(:do_planning_important_activity_checklist).id }/1"
           find("input[value='Eating breakfast'][type='radio']").click
-          select 7, from: "How much pleasure did you expect to get from doing this?"
-          select 3, from: "How much accomplishment do you expect to get from doing this?"
+          select 7, from: "planned_activity[predicted_pleasure_intensity]"
+          select 3, from: "planned_activity[predicted_accomplishment_intensity]"
           click_on "Next"
           visit "/navigator/modules/#{ bit_core_content_modules(:do_planning).id }" \
                     "/providers/" \
@@ -46,8 +46,8 @@ feature "Activities", type: :feature do
                 "#{ bit_core_content_providers(:do_planning_important_activity_checklist).id }/1"
           fill_in "planned_activity[activity_type_new_title]", with: "goat herding"
           find("input[id='new_activity_radio']").click
-          select 5, from: "How much pleasure did you expect to get from doing this?"
-          select 9, from: "How much accomplishment do you expect to get from doing this?"
+          select 5, from: "planned_activity[predicted_pleasure_intensity]"
+          select 9, from: "planned_activity[predicted_accomplishment_intensity]"
           click_on "Next"
           visit "/navigator/modules/#{ bit_core_content_modules(:do_planning).id }" \
                     "/providers/" \


### PR DESCRIPTION
* Change `from:` to use css name instead of the label

[#97428920]