### PR TITLE
Fix Timing Bug In Spec

### DIFF
--- a/spec/features/participant/activities/content_providers/your_activities_provider_spec.rb
+++ b/spec/features/participant/activities/content_providers/your_activities_provider_spec.rb
@@ -8,38 +8,37 @@ feature "Activities", type: :feature do
       context "Participant with activities on days more than 3 days ago" do
         let(:participant) { participants(:seasoned_participant) }
 
-        before do
-          Timecop.return
-          Membership.create!(
-            participant: participant,
-            group: groups(:group1),
-            start_date: Time.zone.today.advance(days: -7),
-            end_date: Time.zone.today.advance(days: 7))
-          Activity.create!(
-            participant: participant,
-            activity_type: activity_types(:sleeping),
-            predicted_accomplishment_intensity: 1,
-            predicted_pleasure_intensity: 2,
-            actual_accomplishment_intensity: 6,
-            actual_pleasure_intensity: 7,
-            start_time: Time.zone.now - 120.hours,
-            end_time: Time.zone.now - 119.hours)
-          sign_in_participant participants(:seasoned_participant)
-          visit "/navigator/modules/#{bit_core_content_modules(:do_your_activities_viz).id}"
-        end
-
         it "alerts are correctly displayed", :js do
-          click_on "Day"
-          click_on "Visualize"
-          click_on "Last 3 Days"
+          Timecop.travel(Timecop.return) do
+            Membership.create!(
+              participant: participant,
+              group: groups(:group1),
+              start_date: Time.zone.today.advance(days: -7),
+              end_date: Time.zone.today.advance(days: 7))
+            Activity.create!(
+              participant: participant,
+              activity_type: activity_types(:sleeping),
+              predicted_accomplishment_intensity: 1,
+              predicted_pleasure_intensity: 2,
+              actual_accomplishment_intensity: 6,
+              actual_pleasure_intensity: 7,
+              start_time: Time.zone.now - 120.hours,
+              end_time: Time.zone.now - 119.hours)
+            sign_in_participant participants(:seasoned_participant)
+            visit "/navigator/modules/#{bit_core_content_modules(:do_your_activities_viz).id}"
+            click_on "Day"
+            click_on "Visualize"
+            click_on "Last 3 Days"
 
-          expect(page).to have_text "Notice! No activities were completed during this 3-day period."
+            expect(page).to have_text "Notice! No activities were completed during this 3-day period."
 
-          click_on "Day"
-          click_on "Visualize"
-          click_on "Last 7 Days"
+            click_on "Day"
+            click_on "Visualize"
+            click_on "Last 7 Days"
 
-          expect(page).to have_text "7-Day View"
+            expect(page).to have_text "7-Day View"
+          end
+          Timecop.travel(Time.local(Date.today.year, 1, 21, 10, 5, 0))
         end
       end
 


### PR DESCRIPTION
Fix Timing Bug In Spec

* Implement an after callback to reset timecop to rails_helper specifications.

[Finished: #97785500]