### PR TITLE
Update When ActiveMemebership is Checked

### DIFF
--- a/app/controllers/think_feel_do_engine/participants/sessions_controller.rb
+++ b/app/controllers/think_feel_do_engine/participants/sessions_controller.rb
@@ -7,15 +7,8 @@ module ThinkFeelDoEngine
       skip_authorization_check
 
       def create
-        participant = Participant.find_by_email params[:participant][:email]
-        if participant && !participant.active_membership
-          msg = "We're sorry, but you can't sign in yet because you are not " \
-                "assigned to a group."
-          redirect_to new_participant_session_path, alert: msg
-        else
-          super do |resource|
-            ParticipantLoginEvent.create(participant_id: resource.id)
-          end
+        super do |resource|
+          ParticipantLoginEvent.create(participant_id: resource.id)
         end
       end
     end

--- a/spec/controllers/think_feel_do_engine/participant_data_controller_spec.rb
+++ b/spec/controllers/think_feel_do_engine/participant_data_controller_spec.rb
@@ -13,7 +13,7 @@ module ThinkFeelDoEngine
     end
     let(:navigator) { instance_double("Navigator", current_content_provider: provider) }
     let(:data_record) { double("data_record") }
-    let(:participant) { double("participant", navigation_status: nil) }
+    let(:participant) { instance_double(Participant, active_membership: true, navigation_status: nil) }
 
     before do
       allow(BitPlayer::Navigator).to receive(:new) { navigator }

--- a/spec/controllers/think_feel_do_engine/participants/activities_controller_spec.rb
+++ b/spec/controllers/think_feel_do_engine/participants/activities_controller_spec.rb
@@ -5,7 +5,7 @@ module ThinkFeelDoEngine
     RSpec.describe ActivitiesController, type: :controller do
       describe "PUT update" do
         let(:activity) { double("activity") }
-        let(:participant) { double("participant") }
+        let(:participant) { instance_double(Participant, active_membership: true) }
 
         context "activity updates with update_as_reviewed" do
           before do

--- a/spec/controllers/think_feel_do_engine/participants/lessons_controller_spec.rb
+++ b/spec/controllers/think_feel_do_engine/participants/lessons_controller_spec.rb
@@ -12,7 +12,7 @@ module ThinkFeelDoEngine
         end
 
         context "for authenticated requests" do
-          let(:participant) { double("participant") }
+          let(:participant) { instance_double(Participant, active_membership: true) }
           let(:arm) { double("arm", id: 123) }
           let(:lesson_tool) { double("lesson tool", title: "LEARN") }
           let(:lesson) { double("lesson") }

--- a/spec/features/participant/alert_messages_spec.rb
+++ b/spec/features/participant/alert_messages_spec.rb
@@ -8,6 +8,6 @@ feature "alert messages", type: :feature do
   end
 
   it "are visible when a user isn't assigned to a group" do
-    expect(page).to have_text("We're sorry, but you can't sign in yet because you are not assigned to a group.")
+    expect(page).to have_text "We're sorry, but you can't sign in yet because you are not assigned to an active group."
   end
 end

--- a/spec/features/participant/inactive_participants_spec.rb
+++ b/spec/features/participant/inactive_participants_spec.rb
@@ -1,9 +1,10 @@
 require "rails_helper"
 
-feature "reset user password", type: :feature do
+feature "Inactive Participant", type: :feature do
   fixtures :all
 
   let(:participant) { participants(:inactive_participant) }
+  let(:message) { "We're sorry, but you can't sign in yet because you are not assigned to an active group." }
 
   before { clear_emails }
 
@@ -15,6 +16,22 @@ feature "reset user password", type: :feature do
     click_on "Change my password"
 
     expect(current_path).to eq "/participants/sign_in"
-    expect(page).to have_content "We're sorry, but you can't sign in yet because you are not assigned to an active group."
+    expect(page).to have_content message
+  end
+
+  describe "Active Participant becoming inactive" do
+    let(:active) { participants(:participant1) }
+
+    it "should logout a participant when requesting a route and their membership is no longer active" do
+      Timecop.travel(active.active_membership.end_date.end_of_day - 5.minutes) do
+        sign_in_participant active
+        Timecop.travel(DateTime.current.advance(minutes: 10)) do
+          visit "/"
+
+          expect(current_path).to eq "/participants/sign_in"
+          expect(page).to have_content message
+        end
+      end
+    end
   end
 end

--- a/spec/support/controller_spec_helpers.rb
+++ b/spec/support/controller_spec_helpers.rb
@@ -1,5 +1,5 @@
 module ControllerSpecHelpers
-  def sign_in_participant(participant = double("participant"))
+  def sign_in_participant(participant = instance_double(Participant, active_membership: true))
     sign_in_resource(participant, "participant")
   end
 


### PR DESCRIPTION
Update When Active Membership is Checked

* Upon any request, check if participant is active.
* If `active_membership` is `nil`, the participant is logged out.

[Finished: #95530436]