### PR TITLE
Remove New Alert from Tools

### DIFF
--- a/app/models/tool_nav_item.rb
+++ b/app/models/tool_nav_item.rb
@@ -17,12 +17,16 @@ class ToolNavItem
   def alert
     case @tool.type
     when nil
-      any_incomplete_tasks_today? ? "New!" : nil
+      any_incomplete_tasks_today? && display_alert(@tool) ? "New!" : nil
     else
       count = @participant.count_all_incomplete(@tool)
 
       count > 0 ? count : nil
     end
+  end
+
+  def display_alert(tool)
+    !%w(RELAX SUPPORT).include?(tool.title)
   end
 
   def is_active?(current_module)

--- a/spec/features/participant/messages_spec.rb
+++ b/spec/features/participant/messages_spec.rb
@@ -45,7 +45,7 @@ feature "messages" do
     end
   end
 
-  it "displays a recieved message" do
+  it "displays a received message" do
     click_on "Try out the LEARN tool"
 
     expect(page).to have_content("Try out the LEARN tool")

--- a/spec/fixtures/bit_core/tools.yml
+++ b/spec/fixtures/bit_core/tools.yml
@@ -31,6 +31,16 @@ messages:
   arm: arm1
   type: Tools::Messages
 
+relax:
+  position: 6
+  title: RELAX
+  arm: arm1
+
+support:
+  position: 7
+  title: SUPPORT
+  arm: arm1
+
 home2:
   position: 0
   title: HOME

--- a/spec/models/tool_nav_item_spec.rb
+++ b/spec/models/tool_nav_item_spec.rb
@@ -47,6 +47,41 @@ describe ToolNavItem do
         end
       end
     end
+
+    context "Support tools exist" do
+      let(:support) { bit_core_tools :support }
+      let(:nav_item) { ToolNavItem.new(participant, support) }
+
+      before do
+        allow(nav_item).to receive(:any_incomplete_tasks_today?) { true }
+      end
+
+      it "returns nil - not 'New!'" do
+        expect(nav_item.alert).to eq nil
+      end
+    end
+  end
+
+  describe "#display_alert" do
+    context "Relax and Support tools exist" do
+      let(:participant) { participants :participant1 }
+      let(:tool) { bit_core_tools :thought_tracker }
+      let(:relax) { bit_core_tools :relax }
+      let(:support) { bit_core_tools :support }
+      let(:nav) { ToolNavItem.new(participant, tool) }
+
+      it "Verifies the alert doesn't display for the relax tool" do
+        expect(nav.display_alert(relax)).to eq false
+      end
+
+      it "Verifies the alert doesn't display for the support tool" do
+        expect(nav.display_alert(support)).to eq false
+      end
+
+      it "Verifies the alert shows for other tools" do
+        expect(nav.display_alert(tool)).to eq true
+      end
+    end
   end
 
   describe "#is_active?" do

--- a/spec/views/think_feel_do_engine/participants/content_modules/index.html.erb_spec.rb
+++ b/spec/views/think_feel_do_engine/participants/content_modules/index.html.erb_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe "think_feel_do_engine/participants/content_modules/index",
   fixtures :all
 
   it "populates the tool_description" do
-    tool = BitCore::Tool.where(type: nil).first
+    tool = BitCore::Tool.where(type: nil, title: "THOUGHT").first
     tool.update description: "Hammer time"
     render template: "think_feel_do_engine/participants/content_modules/index",
            locals: {


### PR DESCRIPTION
Remove New Alert from Tools

* Conditionally load 'New!' for tools
* Support and Relax tools no longer have alert.
* Add model specs to check for conditions.

[Finished: #97468932]