### PR TITLE
Add More Default Emotions To Emotions List

### DIFF
--- a/app/models/participant.rb
+++ b/app/models/participant.rb
@@ -107,7 +107,20 @@ class Participant < ActiveRecord::Base
   end
 
   def populate_emotions
-    %w(Anxious Enthusiastic Grateful Happy Irritable Upset).each do |e|
+    emotions_array = [
+      "Anxious",
+      "Enthusiastic",
+      "Grateful",
+      "Happy",
+      "Irritable",
+      "Upset",
+      "Sad",
+      "Guilty",
+      "Calm",
+      "Concentrated",
+      "Relaxed"
+    ]
+    emotions_array.each do |e|
       emotions.find_or_create_by(name: e)
     end
 

--- a/spec/models/participant_spec.rb
+++ b/spec/models/participant_spec.rb
@@ -26,6 +26,12 @@ describe Participant do
     expect(participant3.notify_by_sms?).to eq true
   end
 
+  it "accurately populates and lists emotions" do
+    expect(participant3.emotions.pluck("name")).not_to include("sad", "guilty", "calm", "concentrated", "relaxed")
+    participant3.populate_emotions
+    expect(participant3.emotions.pluck("name")).to include("sad", "guilty", "calm", "concentrated", "relaxed")
+  end
+
   it ".stepped returns participants that have been stepped" do
     count = Participant.stepped.count
     participant1.active_membership.update(stepped_on: Time.now)


### PR DESCRIPTION
* Add "sad", "guilty" "calm", "concentrated", and "relaxed" to the default selectable emotions list
* Refactor `populate_emotions` to accommodate the longer array; with the additions, the line is too long for rubocop
* Add spec to test that the emotions are being added to the participant correctly

[Finished: #98485282]