### PR TITLE
test on Travis container

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,3 +9,4 @@ notifications:
   slack:
     secure: Ete/aNK2ejpoh/oRAjdm9XBe/8Qvsrkq8/xY/squKDcVClB5TImZRnsc0VGLYfY6H2YXPixJcirfFXh8I6eXuMEte2HVhcz/eKujBD6GzAgJXwGmYONNn2Ph3gYsDBFEowxHRY1okvD6pujaR5IFsTopISXCLLfudBUEkWYzNkI=
     secure: F7EFxB2SVITiZaFFPwk4alJ6Z4KumuuAqFbEoKxh7MseqNEZydGLBHnWIW1XUWvh1ahaQU4P+nS8zYV7lxiXVQsgNV6vCRKqwnou1p0Wqc8jZabpWvyT0oe43q8ofVqAEwL3h8beRuIzJyswfau9eVuoyYk5T3+OowkLrPSnXKY=
+sudo: false


### PR DESCRIPTION
This change allows tests to run on Travis's new Docker-based infrastructure: http://docs.travis-ci.com/user/workers/container-based-infrastructure/

The test suite ran in under 10 minutes, which is over 2 minutes faster than any recent build!