### PR TITLE
Fix markdown changing to visible html tags in group dashboard

### DIFF
--- a/app/views/think_feel_do_engine/manage/groups/_assigned_task_cell.html.erb
+++ b/app/views/think_feel_do_engine/manage/groups/_assigned_task_cell.html.erb
@@ -1,8 +1,16 @@
 <td class="task_title_cell">
 	<!-- use CanCanCan instead -->
 	<% if current_user.content_author? %>
-	  <%= link_to "#{task.bit_core_content_module.tool.title}: #{ task.title }", arm_bit_maker_content_module_path(task.group.arm, task.bit_core_content_module), class: "author_title" %>
+	  <%= link_to(
+	  	arm_bit_maker_content_module_path(
+	  		task.group.arm,
+	  		task.bit_core_content_module
+	  	),
+	  	class: "author_title"
+	  	  ) do %>
+	  	  <%= task.bit_core_content_module.tool.title %>: <%= task.title %>
+	  <% end %>
 	<% else %>
-	  <%= "#{task.bit_core_content_module.tool.title}: #{ task.title }" %>
+		<%= task.bit_core_content_module.tool.title %>: <%= task.title %>
 	<% end %>
 </td>


### PR DESCRIPTION
 * Change link display in "_assigned_task_cell.html.erb" so that `html_safe` strings are preserved in the view (this keeps html tags from appearing in the view)

[Finished: #91858816]