### PR TITLE
Remove highlighting from DO section tables

### DIFF
--- a/app/views/think_feel_do_engine/activities/_past_due_table.erb
+++ b/app/views/think_feel_do_engine/activities/_past_due_table.erb
@@ -14,7 +14,7 @@
           <%= link_to "Edit", edit_link, class: "btn btn-primary pull-right" if edit_link %>
         </p>
 
-        <table class="table table-hover responsive <%=table_name%>">
+        <table class="table responsive <%=table_name%>">
           <thead>
             <th>Activity Test</th>
             <th>Planned For</th>

--- a/app/views/think_feel_do_engine/activities/accomplished_index.html.erb
+++ b/app/views/think_feel_do_engine/activities/accomplished_index.html.erb
@@ -1,6 +1,6 @@
 <p class="lead">Things that make you feel like you've accomplished something.</p>
 
-<table class="table table-hover table-condensed responsive" id="accomplished_activities">
+<table class="table table-condensed responsive" id="accomplished_activities">
 	<tbody>
     <tr>
       <th>Time Period</th>

--- a/app/views/think_feel_do_engine/activities/index.html.erb
+++ b/app/views/think_feel_do_engine/activities/index.html.erb
@@ -1,7 +1,7 @@
 <p class="lead">Take a look - does this all seem right? Recently, you...</p>
 
 <%= form_tag participants_activities_path, remote: true do %>
-  <table class="table table-hover table-condensed responsive" id="recent_activities" >
+  <table class="table table-condensed responsive" id="recent_activities" >
     <tbody>
       <tr>
         <th>Time Period</th>

--- a/app/views/think_feel_do_engine/activities/pleasurable_index.html.erb
+++ b/app/views/think_feel_do_engine/activities/pleasurable_index.html.erb
@@ -1,6 +1,6 @@
 <p class="lead">Things you found fun.</p>
 
-<table class="table responsive table-hover table-condensed" id="fun_activities">
+<table class="table responsive table-condensed" id="fun_activities">
 <tbody>
     <tr>
       <th>Time Period</th>

--- a/app/views/think_feel_do_engine/activities/previously_planned_fullpage.html.erb
+++ b/app/views/think_feel_do_engine/activities/previously_planned_fullpage.html.erb
@@ -1,4 +1,4 @@
-<table class="table table-hover table-condensed" id="previous_activities">
+<table class="table table-condensed" id="previous_activities">
   <thead>
     <th>Activity</th>
     <th>Planned For</th>

--- a/app/views/think_feel_do_engine/activities/unplanned_activity_form.html.erb
+++ b/app/views/think_feel_do_engine/activities/unplanned_activity_form.html.erb
@@ -2,7 +2,7 @@
 
 <p>Green rows are activities you're adding now</p>
 
-<table class="table table-hover table-condensed" id="previous_activities">
+<table class="table table-condensed" id="previous_activities">
   <thead>
     <th>Activity</th>
     <th>Planned For</th>


### PR DESCRIPTION
 * Remove `.table-hover` class from DO tables so that they no longer highlight on hover

[Finished: #97469372]