### PR TITLE
Fix Assigning Task Bug

### DIFF
--- a/app/models/membership.rb
+++ b/app/models/membership.rb
@@ -49,6 +49,10 @@ class Membership < ActiveRecord::Base
     )
   }
 
+  scope :continuing, lambda {
+    where(is_complete: false)
+  }
+
   def available_task_statuses
     @available_task_statuses ||=
       task_statuses

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -62,7 +62,9 @@ class Task < ActiveRecord::Base
   private
 
   def check_if_valid_release_day
-    if group.memberships.any? { |m| release_day > m.length_of_study }
+    if group.active_memberships.continuing.any? do |m|
+         release_day > m.length_of_study
+       end
       errors.add :base, "Release day comes after some members are finished"
 
       false

--- a/spec/fixtures/groups.yml
+++ b/spec/fixtures/groups.yml
@@ -32,3 +32,7 @@ group_for_arm4:
 group5:
   title: Group for Arm 6
   arm: arm6
+
+group6:
+  title: "Group active, discontinued, & withdraw participants"
+  arm: arm1

--- a/spec/models/membership_spec.rb
+++ b/spec/models/membership_spec.rb
@@ -180,6 +180,13 @@ describe Membership do
         " monitored for the first week" do
       expect(membership.logins_by_week(1)).to eq(2)
     end
+
+    it ".continuing returns memberships where `is_complete` is false" do
+      expect do
+        memberships(:membership_participant_complete)
+          .update(is_complete: false)
+      end.to change { Membership.continuing.count }.by(1)
+    end
   end
 
   describe "coach dashboard helper methods" do

--- a/spec/models/task_spec.rb
+++ b/spec/models/task_spec.rb
@@ -29,6 +29,47 @@ describe Task do
     expect(task2.errors.get(:base).count).to eq 1
   end
 
+  describe "Group with discontinued, withdraw, and active memberships" do
+    let(:new_task) do
+      Task.new(
+        group: groups(:group6),
+        release_day: 3,
+        bit_core_content_module: bit_core_content_modules(:do_awareness))
+    end
+
+    def build_membership(attributes = {})
+      Membership.create({
+        participant: participants(:inactive_participant),
+        group: groups(:group6),
+        start_date: Date.today.advance(days: -2),
+        end_date: Date.today.advance(days: -1)
+      }.merge(attributes))
+    end
+
+    it "allows creation of task statuses when an active membership exist" do
+      build_membership(
+        start_date: Date.today,
+        end_date: Date.today.advance(days: 3))
+      new_task.save
+
+      expect(new_task.errors.count).to eq 0
+    end
+
+    it "allows creation of task statuses when a discontinued membership exist" do
+      build_membership(is_complete: true)
+      new_task.save
+
+      expect(new_task.errors.count).to eq 0
+    end
+
+    it "allows creation of task statuses when a withdrawn membership exist" do
+      build_membership
+      new_task.save
+
+      expect(new_task.errors.count).to eq 0
+    end
+  end
+
   it "persists if its creator is destroyed" do
     creator = task1.creator
     creator.destroy


### PR DESCRIPTION
* Change before_save callback `check_if_valid_release_day` to allow tasks to be
  created for memberships that are part of a group containing memberships that
  have either been withdrawn and/or discontinued.
* Add scope `continuing` to find `Memberships` where `is_complete` is `false`.

[Finished: #99521860]