### PR TITLE
Set Cookie From Header For Angular POSTS

### DIFF
--- a/app/controllers/think_feel_do_engine/application_controller.rb
+++ b/app/controllers/think_feel_do_engine/application_controller.rb
@@ -11,6 +11,7 @@ module ThinkFeelDoEngine
     protect_from_forgery with: :exception
 
     before_action :detect_browser, :verify_active_membership
+    after_action :set_csrf_cookie_for_ng
 
     layout "application"
 
@@ -49,6 +50,12 @@ module ThinkFeelDoEngine
       end
     end
 
+    protected
+
+    def verified_request?
+      super || form_authenticity_token == request.headers["X-XSRF-TOKEN"]
+    end
+
     private
 
     def phq_features?
@@ -71,6 +78,11 @@ module ThinkFeelDoEngine
         Devise.sign_out_all_scopes ? sign_out : sign_out(scope)
         redirect_to new_participant_session_path, alert: INACTIVE_MESSAGE
       end
+    end
+
+    def set_csrf_cookie_for_ng
+      return unless protect_against_forgery?
+      cookies["XSRF-TOKEN"] = form_authenticity_token
     end
   end
 end


### PR DESCRIPTION
* The ACHIEVE page is being processed by the ThinkFeelDoEngine::NavigatorController
  When this happens the XSRF token was not set in the cookie (only for SocialNetworking Controllers).
  With no XSRF token set in cookie, the angular POST/PUTs could not proceed and thus the 422.
* Add the `set_csrf_cookie_for_ng` in the TFD Engine application controller and whala!

[Finished: #99525368]