### PR TITLE
Update Last Activity Partial

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -14,9 +14,11 @@ gemspec
 # gem "debugger"
 
 gem "devise", "~> 3.2"
+
 gem "event_capture",
     git: "https://github.com/cbitstech/event_capture.git",
-    ref: "1f9a199"
+    ref: "8d9437"
+
 gem "jquery-datatables-rails",
     tag: "v1.12.0",
     git: "https://github.com/rweng/jquery-datatables-rails.git"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -17,12 +17,11 @@ GIT
 
 GIT
   remote: https://github.com/cbitstech/event_capture.git
-  revision: 1f9a1999f36cf08b7381aae8d9b7715c42a7de01
-  ref: 1f9a199
+  revision: 8d9437a73bc5d43b144b80171a8c8852f3535c89
+  ref: 8d9437
   specs:
-    event_capture (0.0.1)
-      jbuilder
-      rails (>= 4.1.5)
+    event_capture (0.1.0)
+      activerecord (~> 4.1)
 
 GIT
   remote: https://github.com/cbitstech/git_tagger.git
@@ -158,9 +157,6 @@ GEM
       phantomjs
       railties (>= 3.1.0)
       sprockets-rails
-    jbuilder (2.2.5)
-      activesupport (>= 3.0.0, < 5)
-      multi_json (~> 1.2)
     jquery-rails (3.1.2)
       railties (>= 3.0, < 5.0)
       thor (>= 0.14, < 2.0)

--- a/app/models/participant.rb
+++ b/app/models/participant.rb
@@ -102,6 +102,17 @@ class Participant < ActiveRecord::Base
     active_group && active_group.arm.social?
   end
 
+  def duration_of_last_session
+    latest_action_at.to_i - last_sign_in_at.to_i
+  end
+
+  def latest_action_at
+    events
+      .order(recorded_at: :desc)
+      .first
+      .try(:recorded_at)
+  end
+
   def password_is__not_blank?
     !password.blank?
   end

--- a/app/views/think_feel_do_engine/coach/patient_dashboards/tables/_patient_login_stats.html.erb
+++ b/app/views/think_feel_do_engine/coach/patient_dashboards/tables/_patient_login_stats.html.erb
@@ -28,6 +28,24 @@
         <strong>Total Logins:</strong>
         <%= @participant.sign_in_count %>
       </p>
+
+      <p>
+        <strong>Last Activity Detected At:</strong>
+        <% if @participant.events.any? %>
+          <%= l(@participant.latest_action_at, format: :login) %>
+        <% else %>
+          Participant has no events to report.
+       <% end %>
+      </p>
+
+      <p>
+        <strong>Duration of Last Session:</strong>
+        <% if @participant.events.any? %>
+          <%= distance_of_time_in_words(@participant.duration_of_last_session) %>
+        <% else %>
+          Not available because participant has no events to report.
+        <% end %>
+      </p>
     </div>
   </div>
 </div>

--- a/spec/features/coach/patient_dashboard_spec.rb
+++ b/spec/features/coach/patient_dashboard_spec.rb
@@ -429,9 +429,26 @@ feature "patient dashboard", type: :feature do
       it "displays participant's 'Inactive' status on their 'show' page" do
         expect(Rails.application.config).to receive(:study_length_in_weeks).at_least(2).times { 8 }
         visit "/coach/groups/#{group2.id}/patient_dashboards/#{inactive_participant.id }"
-        expect(page).to have_text("Participant TFD-inactive")
-        expect(page).to have_text("Inactive")
-        expect(page).to have_text("Study has been Completed")
+
+        expect(page).to have_text "Participant TFD-inactive"
+        expect(page).to have_text "Inactive"
+        expect(page).to have_text "Study has been Completed"
+        expect(page).to have_text "Participant has no events to report."
+        expect(page).to have_text "Not available because participant has no events to report."
+      end
+
+      it "Displays event info of last detected and the duration" do
+        allow(Rails.application.config).to receive(:study_length_in_weeks) { 0 }
+        participant1.update(last_sign_in_at: DateTime.new(2020, 1, 1, 1, 1, 1))
+        EventCapture::Event
+          .create(participant_id: participant1.id)
+          .update(recorded_at: DateTime.new(2020, 1, 1, 1, 2))
+        visit "/coach/groups/#{group1.id}/patient_dashboards/#{participant1.id}"
+
+        expect(page).to have_text "Last Activity Detected At:"
+        expect(page).to have_text "Wednesday, Jan 01 2020 01:02"
+        expect(page).to have_text "Duration of Last Session:"
+        expect(page).to have_text "1 minute"
       end
     end
 

--- a/spec/models/participant_spec.rb
+++ b/spec/models/participant_spec.rb
@@ -107,4 +107,22 @@ describe Participant do
   it ".most_recent_membership returns membership if a participant has one membership" do
     expect(participant1.most_recent_membership).to be_instance_of Membership
   end
+
+  describe "A recent action exists for a participant" do
+    let(:latest_action) { EventCapture::Event.create(participant_id: participant3.id) }
+
+    before do
+      latest_action.update(recorded_at: DateTime.new(2020, 1, 1, 1, 1, 59))
+    end
+
+    it "#duration_of_last_session returns the length of time between the latest sign in and the most recent event" do
+      participant3.update(last_sign_in_at: DateTime.new(2020, 1, 1, 1, 1, 1))
+
+      expect(participant3.duration_of_last_session).to eq 58
+    end
+
+    it "#latest_action_at returns the most recent event's recorded_at time" do
+      expect(participant3.latest_action_at).to eq latest_action.recorded_at
+    end
+  end
 end


### PR DESCRIPTION
Update Last Activity Partial

* Move `#last_actiion_at` method to Participant model in ThinkFeelDoEngine.
* Update partial to display when the last activity occured.
* Update partial to display duration of last logged in session.
* Update and add feature specs to test conditions if events exist.
* Add model spec to test `#duration_of_last_session` & `#latest_action_at`

[#98851862]