### PR TITLE
Update Event Capture

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,13 +15,13 @@ gemspec
 
 gem "devise", "~> 3.2"
 
-gem "event_capture",
-    git: "https://github.com/cbitstech/event_capture.git",
-    ref: "8d9437"
-
 gem "jquery-datatables-rails",
     tag: "v1.12.0",
     git: "https://github.com/rweng/jquery-datatables-rails.git"
+
+gem "event_capture",
+    tag: "0.1.1",
+    git: "https://github.com/cbitstech/event_capture.git"
 
 gem "bit_core",
     tag: "1.4.2",

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -17,10 +17,10 @@ GIT
 
 GIT
   remote: https://github.com/cbitstech/event_capture.git
-  revision: 8d9437a73bc5d43b144b80171a8c8852f3535c89
-  ref: 8d9437
+  revision: 300f1b1c3aa53aba551612e7a97fd8c0b32129e1
+  tag: 0.1.1
   specs:
-    event_capture (0.1.0)
+    event_capture (0.1.1)
       activerecord (~> 4.1)
 
 GIT

--- a/spec/dummy/db/migrate/20150727163858_change_events_recorded_at_to_null.event_capture.rb
+++ b/spec/dummy/db/migrate/20150727163858_change_events_recorded_at_to_null.event_capture.rb
@@ -1,0 +1,6 @@
+# This migration comes from event_capture (originally 20150727145934)
+class ChangeEventsRecordedAtToNull < ActiveRecord::Migration
+  def change
+    change_column_null :event_capture_events, :recorded_at, false
+  end
+end

--- a/spec/dummy/db/migrate/20150727163859_change_events_emitted_at_to_null.event_capture.rb
+++ b/spec/dummy/db/migrate/20150727163859_change_events_emitted_at_to_null.event_capture.rb
@@ -1,0 +1,6 @@
+# This migration comes from event_capture (originally 20150727151245)
+class ChangeEventsEmittedAtToNull < ActiveRecord::Migration
+  def change
+    change_column_null :event_capture_events, :emitted_at, false
+  end
+end

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150410175659) do
+ActiveRecord::Schema.define(version: 20150727163859) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -188,8 +188,8 @@ ActiveRecord::Schema.define(version: 20150410175659) do
   end
 
   create_table "event_capture_events", force: true do |t|
-    t.datetime "emitted_at"
-    t.datetime "recorded_at"
+    t.datetime "emitted_at",     null: false
+    t.datetime "recorded_at",    null: false
     t.text     "payload"
     t.string   "user_id"
     t.string   "user_agent"

--- a/spec/features/coach/patient_dashboard_spec.rb
+++ b/spec/features/coach/patient_dashboard_spec.rb
@@ -439,10 +439,13 @@ feature "patient dashboard", type: :feature do
 
       it "Displays event info of last detected and the duration" do
         allow(Rails.application.config).to receive(:study_length_in_weeks) { 0 }
-        participant1.update(last_sign_in_at: DateTime.new(2020, 1, 1, 1, 1, 1))
+        participant1.update(last_sign_in_at: Time.zone.local(2020, 1, 1, 1, 1, 1))
         EventCapture::Event
-          .create(participant_id: participant1.id)
-          .update(recorded_at: DateTime.new(2020, 1, 1, 1, 2))
+          .create(
+            emitted_at: Time.zone.now,
+            participant_id: participant1.id
+          )
+          .update(recorded_at: Time.zone.local(2020, 1, 1, 1, 2))
         visit "/coach/groups/#{group1.id}/patient_dashboards/#{participant1.id}"
 
         expect(page).to have_text "Last Activity Detected At:"

--- a/spec/models/participant_spec.rb
+++ b/spec/models/participant_spec.rb
@@ -109,14 +109,19 @@ describe Participant do
   end
 
   describe "A recent action exists for a participant" do
-    let(:latest_action) { EventCapture::Event.create(participant_id: participant3.id) }
+    let(:latest_action) do
+      EventCapture::Event.create(
+        emitted_at: Time.zone.now,
+        participant_id: participant3.id
+      )
+    end
 
     before do
-      latest_action.update(recorded_at: DateTime.new(2020, 1, 1, 1, 1, 59))
+      latest_action.update(recorded_at: Time.zone.local(2020, 1, 1, 1, 1, 59))
     end
 
     it "#duration_of_last_session returns the length of time between the latest sign in and the most recent event" do
-      participant3.update(last_sign_in_at: DateTime.new(2020, 1, 1, 1, 1, 1))
+      participant3.update(last_sign_in_at: Time.zone.local(2020, 1, 1, 1, 1, 1))
 
       expect(participant3.duration_of_last_session).to eq 58
     end

--- a/spec/models/think_feel_do_engine/reports/lesson_slide_view_spec.rb
+++ b/spec/models/think_feel_do_engine/reports/lesson_slide_view_spec.rb
@@ -50,21 +50,6 @@ module ThinkFeelDoEngine
               slide_exited_at: exit_event.emitted_at.iso8601
             )
           end
-
-          it "doesn't raise an error when `emitted_at` is nil" do
-            m = bit_core_content_modules(:slideshow_content_module_2)
-            p = bit_core_content_providers(:content_provider_slideshow_2)
-
-            EventCapture::Event.create!(
-              kind: "render",
-              participant: participants(:participant1),
-              payload: {
-                currentUrl: "http://localhost/navigator/modules/#{ m.id }" \
-                            "/providers/#{ p.id }/1"
-              },
-              emitted_at: nil)
-            expect { LessonSlideView.all_slide_interactions }.not_to raise_error
-          end
         end
       end
     end


### PR DESCRIPTION
Update Event Capture

* Include latest version of event capture 0.1.1
* This version no longer allows emitted_at or recorded_at to be null.

[#98851862]