### PR TITLE
Add New Site Message Helper

### DIFF
--- a/app/controllers/think_feel_do_engine/application_controller.rb
+++ b/app/controllers/think_feel_do_engine/application_controller.rb
@@ -58,20 +58,6 @@ module ThinkFeelDoEngine
 
     private
 
-    def phq_features?
-      if Rails.application.config.respond_to?(:include_phq_features)
-        Rails.application.config.include_phq_features
-      end
-    end
-    helper_method :phq_features?
-
-    def social_features?
-      if Rails.application.config.respond_to?(:include_social_features)
-        Rails.application.config.include_social_features
-      end
-    end
-    helper_method :social_features?
-
     def verify_active_membership
       if current_participant && !current_participant.active_membership
         scope = Devise::Mapping.find_scope!(current_participant)

--- a/app/helpers/think_feel_do_engine/application_helper.rb
+++ b/app/helpers/think_feel_do_engine/application_helper.rb
@@ -2,5 +2,23 @@ module ThinkFeelDoEngine
   # Ensure font awesome icon helpers are available.
   module ApplicationHelper
     include FontAwesome::Rails::IconHelper
+
+    def host_email_link
+      host_url = Rails.application.config.action_mailer
+                 .default_url_options[:host]
+      host_url if host_url
+    end
+
+    def phq_features?
+      if Rails.application.config.respond_to?(:include_phq_features)
+        Rails.application.config.include_phq_features
+      end
+    end
+
+    def social_features?
+      if Rails.application.config.respond_to?(:include_social_features)
+        Rails.application.config.include_social_features
+      end
+    end
   end
 end

--- a/app/views/think_feel_do_engine/coach/site_messages/_form.html.erb
+++ b/app/views/think_feel_do_engine/coach/site_messages/_form.html.erb
@@ -13,7 +13,7 @@
 
   <div class="form-group">
     <%= label_tag "from", nil, class: "control-label" %>
-    <p class="form-control-static">stepped_care-no-reply@northwestern.edu</p>
+    <p class="form-control-static"><%= host_email_link %></p>
   </div>
 
   <div class="form-group">

--- a/spec/helpers/think_feel_do_engine/application_helper_spec.rb
+++ b/spec/helpers/think_feel_do_engine/application_helper_spec.rb
@@ -1,0 +1,61 @@
+require "rails_helper"
+
+module ThinkFeelDoEngine
+  RSpec.describe ApplicationHelper, type: :helper do
+    let(:configuration) { Rails.application.config }
+
+    describe "#host_email_link" do
+      before do
+        configuration.action_mailer.default_url_options[:host] = "sloth@ex.co"
+      end
+
+      it "returns the host application's url" do
+        expect(helper.host_email_link).to eq "sloth@ex.co"
+      end
+    end
+
+    describe "#phq_features?" do
+      context "PHQ features exist" do
+        before do
+          configuration.include_phq_features = true
+        end
+
+        it "returns true" do
+          expect(helper.phq_features?).to eq true
+        end
+      end
+
+      context "PHQ features do not exist" do
+        before do
+          configuration.include_phq_features = false
+        end
+
+        it "returns false" do
+          expect(helper.phq_features?).to eq false
+        end
+      end
+    end
+
+    describe "#social_features?" do
+      context "Social features exist" do
+        before do
+          configuration.include_social_features = true
+        end
+
+        it "returns true" do
+          expect(helper.social_features?).to eq true
+        end
+      end
+
+      context "Social features do not exist" do
+        before do
+          configuration.include_social_features = false
+        end
+
+        it "returns false" do
+          expect(helper.social_features?).to eq false
+        end
+      end
+    end
+  end
+end

--- a/spec/views/think_feel_do_engine/coach/site_messages/_form.html.erb_spec.rb
+++ b/spec/views/think_feel_do_engine/coach/site_messages/_form.html.erb_spec.rb
@@ -1,0 +1,18 @@
+require "rails_helper"
+
+RSpec.describe "think_feel_do_engine/coach/site_messages/_form.html.erb", type: :view do
+  before do
+    allow(view).to receive(:coach_group_site_messages_path) { "" }
+    allow(view).to receive(:host_email_link) { "sloth@ex.co" }
+    assign :site_message, SiteMessage.new
+    assign :participants, []
+  end
+
+  context "as an authenticated user" do
+    it "displays host url link" do
+      render
+
+      expect(rendered).to have_text("sloth@ex.co")
+    end
+  end
+end


### PR DESCRIPTION
Add New Site Message Helper

* Add helper to display host app's email url.
* Add view and helper spec.
* Update `ApplicationHelper` with helper methods from `ApplicationControler`
* Add additional helper specs

[#92731694]