### PR TITLE
add guards on membership date validation

### DIFF
--- a/app/models/membership.rb
+++ b/app/models/membership.rb
@@ -203,7 +203,7 @@ class Membership < ActiveRecord::Base
   end
 
   def not_complete_in_the_future
-    return unless end_date > Date.today && is_complete == true
+    return unless end_date && end_date > Date.today && is_complete == true
 
     errors.add :is_complete, "cannot be set to true for end dates in the future"
   end
@@ -217,7 +217,7 @@ class Membership < ActiveRecord::Base
   end
 
   def not_ending_in_the_past
-    return unless end_date_changed? && end_date < Date.current
+    return unless end_date && end_date_changed? && end_date < Date.current
 
     errors.add :end_date, "must not be in the past"
   end

--- a/spec/models/membership_spec.rb
+++ b/spec/models/membership_spec.rb
@@ -31,7 +31,7 @@ describe Membership do
         .to eq false
     end
 
-    it "prevents is_complete=true and an end_date in the future" do
+    it "does not allow is_complete=true and an end_date in the future" do
       expect(
         Membership.new(end_date: Date.today + 3.days, is_complete: true)
         .tap(&:valid?)
@@ -49,6 +49,15 @@ describe Membership do
       Timecop.travel existing_membership.end_date + 1.day do
         expect(existing_membership).to be_valid
       end
+    end
+
+    it "does not allow a nil end date to be created" do
+      expect(Membership.new(end_date: nil).tap(&:valid?).errors[:end_date].length)
+        .to be > 0
+    end
+
+    it "does not allow a nil end date to be updated" do
+      expect(Membership.first.update(end_date: nil)).to eq false
     end
   end
 


### PR DESCRIPTION
* when dates are nil, the validation should be handled by the
  presence validator

[##99708210]