### PR TITLE
Change Duration Calculation

### DIFF
--- a/app/models/participant.rb
+++ b/app/models/participant.rb
@@ -103,7 +103,7 @@ class Participant < ActiveRecord::Base
   end
 
   def duration_of_last_session
-    latest_action_at.to_i - last_sign_in_at.to_i
+    latest_action_at - current_sign_in_at
   end
 
   def latest_action_at

--- a/spec/features/coach/patient_dashboard_spec.rb
+++ b/spec/features/coach/patient_dashboard_spec.rb
@@ -428,7 +428,7 @@ feature "patient dashboard", type: :feature do
 
       it "displays participant's 'Inactive' status on their 'show' page" do
         expect(Rails.application.config).to receive(:study_length_in_weeks).at_least(2).times { 8 }
-        visit "/coach/groups/#{group2.id}/patient_dashboards/#{inactive_participant.id }"
+        visit "/coach/groups/#{group2.id}/patient_dashboards/#{inactive_participant.id}"
 
         expect(page).to have_text "Participant TFD-inactive"
         expect(page).to have_text "Inactive"
@@ -439,7 +439,7 @@ feature "patient dashboard", type: :feature do
 
       it "Displays event info of last detected and the duration" do
         allow(Rails.application.config).to receive(:study_length_in_weeks) { 0 }
-        participant1.update(last_sign_in_at: Time.zone.local(2020, 1, 1, 1, 1, 1))
+        participant1.update(current_sign_in_at: Time.zone.local(2020, 1, 1, 1, 1, 1))
         EventCapture::Event
           .create(
             emitted_at: Time.zone.now,

--- a/spec/models/participant_spec.rb
+++ b/spec/models/participant_spec.rb
@@ -120,8 +120,8 @@ describe Participant do
       latest_action.update(recorded_at: Time.zone.local(2020, 1, 1, 1, 1, 59))
     end
 
-    it "#duration_of_last_session returns the length of time between the latest sign in and the most recent event" do
-      participant3.update(last_sign_in_at: Time.zone.local(2020, 1, 1, 1, 1, 1))
+    it "#duration_of_last_session returns the length of time between the current sign in and the most recent event" do
+      participant3.update(current_sign_in_at: Time.zone.local(2020, 1, 1, 1, 1, 1))
 
       expect(participant3.duration_of_last_session).to eq 58
     end


### PR DESCRIPTION
* Wrong assumption was made about `last_sign_in_at`
* Using method `current_sign_in_at` on `Participant`
* `current_sign_in_at` and `last_sign_in_at` are the same if the participant  
  logs in for the first time.
* `current_sign_in_at` is the timestamp we want even if the participant is logged out
* `last_sign_in_at gets` updated when the participant logs back in.

[Finished: #98851862]