### PR TITLE
ensure module session reports succeed

### DIFF
--- a/app/models/think_feel_do_engine/reports/module_session.rb
+++ b/app/models/think_feel_do_engine/reports/module_session.rb
@@ -115,10 +115,15 @@ module ThinkFeelDoEngine
                         .content_providers
                         .order(:position)
                         .last
-        provider_re = "modules\/#{ module_id }\/" \
-                      "providers\/#{ last_provider.id }(\/.*)?$"
 
-        !url.match(/#{ provider_re }/).nil?
+        if last_provider.nil?
+          false
+        else
+          provider_re = "modules\/#{ module_id }\/" \
+                        "providers\/#{ last_provider.id }(\/.*)?$"
+
+          !url.match(/#{ provider_re }/).nil?
+        end
       end
     end
   end

--- a/spec/models/think_feel_do_engine/reports/module_session_spec.rb
+++ b/spec/models/think_feel_do_engine/reports/module_session_spec.rb
@@ -100,6 +100,28 @@ module ThinkFeelDoEngine
             )
           end
         end
+
+        context "when the module viewed has no last provider" do
+          it "records false for did_complete" do
+            EventCapture::Event.destroy_all
+            ContentProviderPolicy.destroy_all
+            BitCore::ContentProvider.destroy_all
+            now = Time.current
+            module_id = bit_core_content_modules(:do_awareness).id
+            render!(emitted_at: now - 10.minutes,
+                    url: "/navigator/modules/#{ module_id }")
+
+            expect(data.count).to eq 1
+            expect(data).to include(
+              participant_id: "TFD-1111",
+              module_id: module_id,
+              page_headers: ["a", "b", "c"],
+              module_selected_at: (now - 10.minutes).utc.iso8601,
+              last_page_opened_at: (now - 10.minutes).utc.iso8601,
+              did_complete: false
+            )
+          end
+        end
       end
     end
   end


### PR DESCRIPTION
* even if for some reason a module is missing a provider, the report
  generation should still succeed

[#100846610]