### PR TITLE
Add Study Lesson Length

### DIFF
--- a/app/helpers/think_feel_do_engine/coach/dashboard_and_phq_table_helper.rb
+++ b/app/helpers/think_feel_do_engine/coach/dashboard_and_phq_table_helper.rb
@@ -30,9 +30,7 @@ module ThinkFeelDoEngine
       end
 
       def study_length_in_weeks
-        if Rails.application.config.respond_to?(:study_length_in_weeks)
-          Rails.application.config.study_length_in_weeks
-        end
+        Rails.application.config.study_length_in_weeks
       end
 
       private

--- a/app/models/content_providers/learn_lessons_index_provider.rb
+++ b/app/models/content_providers/learn_lessons_index_provider.rb
@@ -1,7 +1,6 @@
 module ContentProviders
   # Provides a view of current learning tools: videos and lessons
   class LearnLessonsIndexProvider < BitCore::ContentProvider
-    DEFAULT_STUDY_LENGTH = 16
     DAYS_IN_WEEK = 7
 
     def render_current(options)
@@ -50,9 +49,7 @@ module ContentProviders
     end
 
     def week_count
-      Rails.application.config.study_length_in_weeks
-    rescue
-      DEFAULT_STUDY_LENGTH
+      Rails.application.config.lesson_week_length
     end
   end
 end

--- a/app/views/think_feel_do_engine/coach/group_dashboard/_lessons.html.erb
+++ b/app/views/think_feel_do_engine/coach/group_dashboard/_lessons.html.erb
@@ -4,7 +4,7 @@
   </div>
 
   <div class="panel-body">
-    <% (1..Rails.application.config.study_length_in_weeks).each do |week_number| %>
+    <% (1..study_length_in_weeks).each do |week_number| %>
       <h2>Week <%= week_number %></h2>
       <table class="table">
         <% group.learning_tasks.each do |task| %>

--- a/config/initializers/think_feel_do_engine.rb
+++ b/config/initializers/think_feel_do_engine.rb
@@ -1,0 +1,4 @@
+Rails.application.configure do
+  config.lesson_week_length = 0
+  config.study_length_in_weeks = 0
+end

--- a/spec/features/participant/learn/content_providers/learn_lesson_provider_spec.rb
+++ b/spec/features/participant/learn/content_providers/learn_lesson_provider_spec.rb
@@ -1,0 +1,30 @@
+require "rails_helper"
+
+feature "Learn", type: :feature do
+  fixtures :all
+
+  describe "When in learning" do
+    describe "ContentProvider::LearnLessonsIndexProvider" do
+      describe "When lesson availability is set to 0" do
+        let(:participant1) { participants(:participant1) }
+
+        before do
+          Rails.application.config.lesson_week_length = 0
+        end
+
+        after do
+          Rails.application.config.lesson_week_length = 16
+        end
+
+        scenario "No lessons are available for any weeks" do
+          sign_in_participant participant1
+          visit "/navigator/contexts/LEARN"
+
+          within ".panel-group" do
+            expect(page).not_to have_text "Week 1"
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -45,6 +45,8 @@ RSpec.configure do |config|
   config.use_transactional_fixtures = false
 
   config.before(:suite) do
+    Rails.application.config.lesson_week_length = 16
+    Rails.application.config.study_length_in_weeks = 16
     DatabaseCleaner.clean_with(:truncation)
   end
 


### PR DESCRIPTION
* Add Rails config study length to display lessons.
* Add defaults if host apps don't have necessary configurations.
* Remove rescue and default statements.

[#104761294]